### PR TITLE
Refactor detecting ethereum provider and connect/disconnect stuff

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { HashRouter, Route, Routes } from 'react-router-dom'
 import Home from './components/pages/Home'
 import Chat from './components/pages/Chat'
 import Store from './components/Store'
+import EthereumProviderDetector from './components/EthereumProviderDetector'
 
 const Global = createGlobalStyle`
     html,
@@ -32,6 +33,7 @@ const Global = createGlobalStyle`
 export default function App() {
     return (
         <Store>
+            <EthereumProviderDetector />
             <Global />
             <HashRouter>
                 <Routes>

--- a/src/components/EthereumProviderDetector.tsx
+++ b/src/components/EthereumProviderDetector.tsx
@@ -1,0 +1,39 @@
+import detectEthereumProvider from '@metamask/detect-provider'
+import { MetaMaskInpageProvider } from '@metamask/providers'
+import { useEffect } from 'react'
+import { ActionType, useDispatch } from '../components/Store'
+
+export default function EthereumProviderDetector() {
+    const dispatch = useDispatch()
+
+    useEffect(() => {
+        let mounted = true
+
+        async function detect() {
+            let provider: MetaMaskInpageProvider
+
+            try {
+                provider = await detectEthereumProvider() as MetaMaskInpageProvider
+
+                if (!mounted) {
+                    return
+                }
+
+                dispatch({
+                    type: ActionType.SetEthereumProvider,
+                    payload: provider,
+                })
+            } catch (e) {
+                console.warn('Ethereum provider could not be detected.')
+            }
+        }
+
+        detect()
+
+        return () => {
+            mounted = false
+        }
+    }, [dispatch])
+
+    return null
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,9 +2,10 @@ import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import Button from './Button'
 import { KARELIA, SEMIBOLD } from '../utils/css'
-import { initializeMetamaskDelegatedAccess } from '../lib/MetamaskDelegatedAccess'
 import AddressButton from './AddressButton'
-import { ActionType, useDispatch, useStore } from './Store'
+import { useStore } from './Store'
+import useConnect from '../hooks/useConnect'
+import useDisconnect from '../hooks/useDisconnect'
 
 type Props = {
     className?: string
@@ -17,37 +18,22 @@ const ConnectButton = styled(Button)`
 `
 
 const UnstyledNavbar = ({ className }: Props) => {
-    const dispatch = useDispatch()
-    const store = useStore()
-    const connect = async () => {
-        const access = await initializeMetamaskDelegatedAccess()
-        console.info(
-            `connected with Metamask address: ${access.metamask.address}`
-        )
-        console.info(
-            `connected with session address: ${access.session.address}`
-        )
+    const { metamaskAddress } = useStore()
 
-        dispatch({
-            type: ActionType.SetSession,
-            payload: access,
-        })
-    }
+    const connect = useConnect()
 
-    const disconnect = () => {
-        localStorage.clear()
-        window.location.reload()
-    }
+    const disconnect = useDisconnect()
+
     return (
         <nav className={className}>
             <h4>
                 <Link to="/">thechat.eth</Link>
             </h4>
-            {store.metamaskAddress ? (
+            {metamaskAddress ? (
                 <AddressButton
                     type="button"
                     onClick={disconnect}
-                    address={store.metamaskAddress}
+                    address={metamaskAddress}
                 />
             ) : (
                 <ConnectButton type="button" onClick={connect}>

--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -176,7 +176,7 @@ function reducer(state: ChatState, action: A): ChatState {
                       ],
                   })
         case ActionType.SetSession:
-            const { session, metamask, provider } = action.payload
+            const { session, metamask } = action.payload
 
             const streamrClient = new StreamrClient({
                 auth: {
@@ -190,7 +190,6 @@ function reducer(state: ChatState, action: A): ChatState {
                 session: {
                     wallet: new Wallet(session.privateKey),
                     streamrClient,
-                    provider: provider,
                 },
             }
         case ActionType.SetEthereumProvider:

--- a/src/components/pages/Chat/index.tsx
+++ b/src/components/pages/Chat/index.tsx
@@ -29,7 +29,7 @@ type Props = {
 
 const UnstyledChat = ({ className }: Props) => {
     const messages = useMessages()
-    const { roomId, rooms, metamaskAddress, session } = useStore()
+    const { roomId, rooms, metamaskAddress, session, ethereumProvider } = useStore()
     const dispatch = useDispatch()
 
     useEffect(() => {
@@ -43,7 +43,7 @@ const UnstyledChat = ({ className }: Props) => {
             await fetchRooms(
                 session.streamrClient!,
                 session.wallet!.address,
-                session.provider!,
+                ethereumProvider!,
                 (chatRoom: ChatRoom) => {
                     dispatch({
                         type: ActionType.AddRooms,
@@ -54,7 +54,7 @@ const UnstyledChat = ({ className }: Props) => {
         }
 
         fn()
-    }, [dispatch, metamaskAddress, session])
+    }, [dispatch, metamaskAddress, session, ethereumProvider])
 
     return (
         <>

--- a/src/getters/getInitialStoreState.ts
+++ b/src/getters/getInitialStoreState.ts
@@ -12,7 +12,6 @@ export default function getInitialChatState(): ChatState {
         roomNameEditable: false,
         rooms: [],
         session: {
-            provider: undefined,
             streamrClient: undefined,
             wallet: undefined,
         },

--- a/src/getters/getInitialStoreState.ts
+++ b/src/getters/getInitialStoreState.ts
@@ -1,0 +1,20 @@
+import { ChatState } from "../utils/types";
+
+export default function getInitialChatState(): ChatState {
+    return {
+        drafts: {},
+        ethereumProvider: undefined,
+        ethereumProviderReady: false,
+        identity: undefined,
+        messages: {},
+        metamaskAddress: '',
+        roomId: undefined,
+        roomNameEditable: false,
+        rooms: [],
+        session: {
+            provider: undefined,
+            streamrClient: undefined,
+            wallet: undefined,
+        },
+    }
+}

--- a/src/hooks/useConnect.ts
+++ b/src/hooks/useConnect.ts
@@ -1,0 +1,18 @@
+import { useCallback } from "react"
+import { ActionType, useDispatch, useStore } from "../components/Store"
+import { MetamaskDelegatedAccess } from "../lib/MetamaskDelegatedAccess"
+
+export default function useConnect(): () => Promise<void> {
+    const { ethereumProvider } = useStore()
+
+    const dispatch = useDispatch()
+
+    return useCallback(async () => {
+        const payload = await (new MetamaskDelegatedAccess(ethereumProvider!)).connect()
+
+        dispatch({
+            type: ActionType.SetSession,
+            payload,
+        })
+    }, [ethereumProvider, dispatch])
+}

--- a/src/hooks/useDisconnect.ts
+++ b/src/hooks/useDisconnect.ts
@@ -1,0 +1,14 @@
+import { useCallback } from "react"
+import { ActionType, useDispatch } from "../components/Store"
+
+export default function useDisconnect() {
+    const dispatch = useDispatch()
+
+    return useCallback(() => {
+        localStorage.clear()
+
+        dispatch({
+            type: ActionType.Reset,
+        })
+    }, [dispatch])
+}

--- a/src/lib/MetamaskDelegatedAccess.ts
+++ b/src/lib/MetamaskDelegatedAccess.ts
@@ -26,7 +26,7 @@ export class MetamaskDelegatedAccess {
         }
     }
 
-    public async connect(): Promise<void> {
+    public async connect(): Promise<MetamaskDelegatedAccess> {
         // enable and fetch metamask account
         const providers = (await this.provider.request({
             method: 'eth_requestAccounts',
@@ -49,6 +49,8 @@ export class MetamaskDelegatedAccess {
 
         this.session.address = sessionWallet.address
         this.session.privateKey = sessionWallet.privateKey
+
+        return this
     }
 
     private async createAccount(): Promise<Wallet> {
@@ -97,12 +99,4 @@ export const detectTypedEthereumProvider =
             throw new Error('MetaMask not detected')
         }
         return provider
-    }
-
-export const initializeMetamaskDelegatedAccess =
-    async (): Promise<MetamaskDelegatedAccess> => {
-        const provider = await detectTypedEthereumProvider()
-        const accessManager = new MetamaskDelegatedAccess(provider)
-        await accessManager.connect()
-        return accessManager
     }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -42,7 +42,6 @@ export interface ChatMessage {
 export interface StreamrSession {
     wallet: Wallet | undefined
     streamrClient: StreamrClient | undefined
-    provider: MetaMaskInpageProvider | undefined
 }
 
 export interface ChatRoom {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,6 +26,8 @@ export type ChatState = {
     rooms: ChatRoom[]
     metamaskAddress: string
     session: StreamrSession
+    ethereumProvider: MetaMaskInpageProvider | undefined
+    ethereumProviderReady: boolean
 }
 
 export enum MessageType {


### PR DESCRIPTION
In this PR I'm extracting ethereum provider piece into a separate component that does just that, detects the provider. And it does that proactively before anything else happens. See where I put it (i.e. `App.tsx`).

Then I use that provider across the app. It replaces `store.session.provider`.

I also make `useConnect` and `useDisconnect` hooks and use them in `Navbar`. Makes it more modular.

More coming.