### PR TITLE
[FRONT-923] Stream privacy functionality (access control)

### DIFF
--- a/src/components/pages/Chat/AddRoomModal/AddRoomItem.tsx
+++ b/src/components/pages/Chat/AddRoomModal/AddRoomItem.tsx
@@ -177,10 +177,7 @@ function UnstyledAddRoomItem(props: Props) {
                     <ModalContainer>
                         <ModalHeader>
                             <h2>Create new room</h2>
-                            <CloseButton
-                                onClick={closeModal}
-                                type="button"
-                            >
+                            <CloseButton onClick={closeModal} type="button">
                                 <svg
                                     width="16"
                                     height="16"
@@ -207,10 +204,15 @@ function UnstyledAddRoomItem(props: Props) {
                             <form
                                 onSubmit={(e) => {
                                     if (!privacyValue) {
-                                        throw new Error('Privacy cannot be blank')
+                                        throw new Error(
+                                            'Privacy cannot be blank'
+                                        )
                                     }
 
-                                    createRoom({ roomName, privacy: privacyValue as any })
+                                    createRoom({
+                                        roomName,
+                                        privacy: privacyValue as any,
+                                    })
                                     closeModal()
                                     e.preventDefault()
                                 }}
@@ -233,7 +235,9 @@ function UnstyledAddRoomItem(props: Props) {
                                 <Subheading>Choose privacy</Subheading>
                                 <PrivacySelect
                                     value={privacy}
-                                    onChange={(option: any) => void setPrivacy(option)}
+                                    onChange={(option: any) =>
+                                        void setPrivacy(option)
+                                    }
                                 />
                                 <CreateButton
                                     type="submit"

--- a/src/components/pages/Chat/AddRoomModal/AddRoomItem.tsx
+++ b/src/components/pages/Chat/AddRoomModal/AddRoomItem.tsx
@@ -119,7 +119,9 @@ function UnstyledAddRoomItem(props: Props) {
     const createRoom = useCreateRoom()
     const [modalIsOpen, setModalIsOpen] = useState(false)
     const [roomName, setRoomName] = useState(getRandomRoomName())
-    const [privacy, setPrivacy] = useState()
+    const [privacy, setPrivacy] = useState<any>()
+
+    const { value: privacyValue } = privacy || {}
 
     const closeModal = () => {
         setModalIsOpen(false)
@@ -204,7 +206,11 @@ function UnstyledAddRoomItem(props: Props) {
                         <div>
                             <form
                                 onSubmit={(e) => {
-                                    createRoom(roomName)
+                                    if (!privacyValue) {
+                                        throw new Error('Privacy cannot be blank')
+                                    }
+
+                                    createRoom({ roomName, privacy: privacyValue as any })
                                     closeModal()
                                     e.preventDefault()
                                 }}

--- a/src/components/pages/Chat/AddRoomModal/PrivacySelect.tsx
+++ b/src/components/pages/Chat/AddRoomModal/PrivacySelect.tsx
@@ -68,13 +68,13 @@ const LabelContainer = styled.div`
     margin-right: auto;
 
     p {
-        color: #36404E;
+        color: #36404e;
         font-size: 14px;
         margin: 0;
     }
 
     p + p {
-        color: #59799C;
+        color: #59799c;
         font-size: 12px;
     }
 `
@@ -97,7 +97,7 @@ const CheckIcon = styled.img`
 `
 
 const ControlIcon = styled.div`
-    color: #59799C;
+    color: #59799c;
 
     img {
         display: block;
@@ -130,17 +130,15 @@ const Option = ({ data: { icon, label, subLabel }, ...props }: any) => (
 )
 
 function Control({ children, ...props }: any) {
-    const { selectProps: { value } } = props
+    const {
+        selectProps: { value },
+    } = props
 
     const { icon } = value || {}
 
     return (
         <components.Control {...props}>
-            <ControlIcon>
-                {!!icon && (
-                    <img src={icon} alt="" />
-                )}
-            </ControlIcon>
+            <ControlIcon>{!!icon && <img src={icon} alt="" />}</ControlIcon>
             {children}
         </components.Control>
     )

--- a/src/components/pages/Chat/MessageInterceptor.tsx
+++ b/src/components/pages/Chat/MessageInterceptor.tsx
@@ -59,7 +59,10 @@ const MessageInterceptor = memo(
                 const stream = await streamrClient!.getStream(streamId)
                 const { privacy } = getRoomMetadata(stream.description!)
                 // prevent subscribing on metadata for public and view-only rooms
-                if (privacy !== 'private' && streamPartition !== Partition.Messages){
+                if (
+                    privacy !== 'private' &&
+                    streamPartition !== Partition.Messages
+                ) {
                     return
                 }
                 try {
@@ -69,7 +72,6 @@ const MessageInterceptor = memo(
                             partition: streamPartition,
                         },
                         (data: any, raw: StreamMessage) => {
-                            console.warn('msg', data)
                             if (!mounted) {
                                 return
                             }

--- a/src/components/pages/Chat/MessageInterceptor.tsx
+++ b/src/components/pages/Chat/MessageInterceptor.tsx
@@ -4,6 +4,7 @@ import { useStore } from '../../Store'
 import { useSend } from './MessageTransmitter'
 import { MetadataType } from './MessageAggregator'
 import { StreamMessage } from 'streamr-client-protocol'
+import getRoomMetadata from '../../../getters/getRoomMetadata'
 
 type Props = {
     streamId: string
@@ -55,6 +56,12 @@ const MessageInterceptor = memo(
             }
 
             async function fn() {
+                const stream = await streamrClient!.getStream(streamId)
+                const { privacy } = getRoomMetadata(stream.description!)
+                // prevent subscribing on metadata for public and view-only rooms
+                if (privacy !== 'private' && streamPartition !== Partition.Messages){
+                    return
+                }
                 try {
                     sub = await streamrClient!.subscribe(
                         {
@@ -62,6 +69,7 @@ const MessageInterceptor = memo(
                             partition: streamPartition,
                         },
                         (data: any, raw: StreamMessage) => {
+                            console.warn('msg', data)
                             if (!mounted) {
                                 return
                             }

--- a/src/components/pages/Chat/MessageTransmitter.tsx
+++ b/src/components/pages/Chat/MessageTransmitter.tsx
@@ -146,7 +146,10 @@ export default function MessageTransmitter({ children }: Props) {
                         await deleteRoom(roomId)
                         return
                     case Command.New:
-                        await createRoom(arg)
+                        await createRoom({
+                            roomName: arg,
+                            privacy: 'private',
+                        })
                         return
                     case Command.Members:
                         const stream = await streamrClient.getStream(roomId)
@@ -178,7 +181,7 @@ export default function MessageTransmitter({ children }: Props) {
                                     ROOM_PREFIX,
                                     {
                                         user: account!,
-                                        anyOf: [StreamPermission.GRANT],
+                                        anyOf: [StreamPermission.GRANT, StreamPermission.SUBSCRIBE],
                                         allowPublic: true,
                                     }
                                 )
@@ -187,7 +190,7 @@ export default function MessageTransmitter({ children }: Props) {
                                 try {
                                     await stream.revokePermissions({
                                         user: account!,
-                                        permissions: [StreamPermission.GRANT],
+                                        permissions: [StreamPermission.GRANT, StreamPermission.SUBSCRIBE],
                                     })
                                     console.info(
                                         `revoked permissions for ${stream.id}`

--- a/src/components/pages/Chat/MessageTransmitter.tsx
+++ b/src/components/pages/Chat/MessageTransmitter.tsx
@@ -37,6 +37,7 @@ enum Command {
     IsMember = 'isMember',
     Purge = 'purge',
     Export = 'export',
+    Join = 'join',
 }
 
 export default function MessageTransmitter({ children }: Props) {
@@ -72,7 +73,7 @@ export default function MessageTransmitter({ children }: Props) {
 
                 const [command, arg] = (
                     payload.match(
-                        /\/(invite|delete|new|rename|members|revoke|isMember|purge|export)\s*(.+)?\s*$/
+                        /\/(invite|delete|new|rename|members|revoke|isMember|purge|export|join)\s*(.+)?\s*$/
                     ) || []
                 ).slice(1)
 
@@ -217,6 +218,8 @@ export default function MessageTransmitter({ children }: Props) {
                         alert(
                             `This is your session's private key:\n${privateKey}`
                         )
+                        return
+                    case Command.Join:
                         return
                     default:
                         break

--- a/src/components/pages/Chat/MessageTransmitter.tsx
+++ b/src/components/pages/Chat/MessageTransmitter.tsx
@@ -183,7 +183,10 @@ export default function MessageTransmitter({ children }: Props) {
                                     ROOM_PREFIX,
                                     {
                                         user: account!,
-                                        anyOf: [StreamPermission.GRANT, StreamPermission.SUBSCRIBE],
+                                        anyOf: [
+                                            StreamPermission.GRANT,
+                                            StreamPermission.SUBSCRIBE,
+                                        ],
                                         allowPublic: true,
                                     }
                                 )
@@ -192,7 +195,10 @@ export default function MessageTransmitter({ children }: Props) {
                                 try {
                                     await stream.revokePermissions({
                                         user: account!,
-                                        permissions: [StreamPermission.GRANT, StreamPermission.SUBSCRIBE],
+                                        permissions: [
+                                            StreamPermission.GRANT,
+                                            StreamPermission.SUBSCRIBE,
+                                        ],
                                     })
                                     console.info(
                                         `revoked permissions for ${stream.id}`
@@ -253,7 +259,7 @@ export default function MessageTransmitter({ children }: Props) {
                 try {
                     const stream = await streamrClient.getStream(streamId)
                     const { privacy } = getRoomMetadata(stream.description!)
-                    if (privacy === 'private'){
+                    if (privacy === 'private') {
                         await streamrClient.publish(
                             streamId,
                             {

--- a/src/hooks/useCreateRoom.ts
+++ b/src/hooks/useCreateRoom.ts
@@ -85,7 +85,7 @@ export default function useCreateRoom(): ({
             }
 
             console.info(
-                `Invited session account ${sessionAccount} to stream ${stream.id}`
+                `Assigned ${privacy} permissions to stream ${stream.id}`
             )
 
             dispatch({

--- a/src/hooks/useCreateRoom.ts
+++ b/src/hooks/useCreateRoom.ts
@@ -1,9 +1,18 @@
 import { useCallback } from 'react'
+import { StreamPermission } from 'streamr-client'
 import { ActionType, useDispatch, useStore } from '../components/Store'
 import { RoomMetadata } from '../utils/types'
 import useInviterSelf from './useInviterSelf'
+import useSetPublicPermissions from './useSetPublicPermissions'
 
-export default function useCreateRoom(): (roomName: string) => Promise<void> {
+type Options = {
+    roomName: string
+    privacy: 'private' | 'viewonly' | 'public'
+}
+export default function useCreateRoom(): ({
+    roomName,
+    privacy,
+}: Options) => Promise<void> {
     const {
         session: { wallet },
         account,
@@ -13,11 +22,12 @@ export default function useCreateRoom(): (roomName: string) => Promise<void> {
     const sessionAccount = wallet?.address
 
     const inviteSelf = useInviterSelf()
+    const setPublicPermissions = useSetPublicPermissions()
 
     const dispatch = useDispatch()
 
     return useCallback(
-        async (roomName: string) => {
+        async ({ roomName, privacy }) => {
             if (!sessionAccount) {
                 throw new Error('Missing session account')
             }
@@ -49,9 +59,29 @@ export default function useCreateRoom(): (roomName: string) => Promise<void> {
 
             console.info(`Created stream ${stream.id}`)
 
-            await inviteSelf({
-                streamIds: [stream.id],
-            })
+            switch (privacy) {
+                case 'private':
+                    await inviteSelf({
+                        streamIds: [stream.id],
+                    })
+                    break
+
+                case 'viewonly':
+                    await inviteSelf({
+                        streamIds: [stream.id],
+                        includePublicPermissions: true
+                    })
+                    break
+                case 'public':
+                    await setPublicPermissions({
+                        permissions: [
+                            StreamPermission.PUBLISH,
+                            StreamPermission.SUBSCRIBE,
+                        ],
+                        stream,
+                    })
+                    break
+            }
 
             console.info(
                 `Invited session account ${sessionAccount} to stream ${stream.id}`

--- a/src/hooks/useCreateRoom.ts
+++ b/src/hooks/useCreateRoom.ts
@@ -49,6 +49,7 @@ export default function useCreateRoom(): ({
             const description: RoomMetadata = {
                 name: normalizedRoomName,
                 createdAt: Date.now(),
+                privacy
             }
 
             const stream = await metamaskStreamrClient.createStream({

--- a/src/hooks/useCreateRoom.ts
+++ b/src/hooks/useCreateRoom.ts
@@ -49,7 +49,7 @@ export default function useCreateRoom(): ({
             const description: RoomMetadata = {
                 name: normalizedRoomName,
                 createdAt: Date.now(),
-                privacy
+                privacy,
             }
 
             const stream = await metamaskStreamrClient.createStream({
@@ -70,7 +70,7 @@ export default function useCreateRoom(): ({
                 case 'viewonly':
                     await inviteSelf({
                         streamIds: [stream.id],
-                        includePublicPermissions: true
+                        includePublicPermissions: true,
                     })
                     break
                 case 'public':
@@ -93,6 +93,13 @@ export default function useCreateRoom(): ({
                 payload: [stream.id],
             })
         },
-        [sessionAccount, metamaskStreamrClient, account, inviteSelf, dispatch]
+        [
+            sessionAccount,
+            metamaskStreamrClient,
+            account,
+            inviteSelf,
+            dispatch,
+            setPublicPermissions,
+        ]
     )
 }

--- a/src/hooks/useExistingRooms.ts
+++ b/src/hooks/useExistingRooms.ts
@@ -4,6 +4,7 @@ import { ActionType, useDispatch, useStore } from '../components/Store'
 import { StorageKey } from '../utils/types'
 import intersection from 'lodash/intersection'
 import useInviterSelf from './useInviterSelf'
+import getRoomMetadata from '../getters/getRoomMetadata'
 
 export const ROOM_PREFIX = 'streamr-chat/room'
 
@@ -55,38 +56,17 @@ export default function useExistingRooms() {
             const selfInviteStreams: string[] = []
             for await (const stream of streams) {
                 try {
-                    /*
+                    const metadata = getRoomMetadata(stream.description!)
+
                     const hasPermission = await stream.hasPermission({
                         user: sessionAccount!,
                         permission: StreamPermission.SUBSCRIBE,
                         allowPublic: true,
-                    })*/
-                    const permissions = await stream.getPermissions()
-
-                    let hasUserPermission = false 
-                    //let hasPublicPermission = false
-
-                    for (let i = 0; i < permissions.length; i++){
-                        const permission = permissions[i]
-                        if ((permission as UserPermissionAssignment).user === sessionAccount && permission.permissions.includes(StreamPermission.PUBLISH)){
-                            hasUserPermission = true
-                        }
-/*
-                        if ((permission as PublicPermissionAssignment).public){
-                            hasPublicPermission = true
-                        }*/
-                    }
-
-                    if (
-                        !hasUserPermission){
+                    })
+                    
+                    if (!hasPermission && metadata.privacy !== 'public' ) {
                         selfInviteStreams.push(stream.id)
                     }
-
-                    /*
-                    console.log('hasPermission',stream.id,  hasPermission, permissions)
-                    if (!hasPermission) {
-                        selfInviteStreams.push(stream.id)
-                    }*/
                     remoteRoomIds.push(stream.id)
                     dispatch({
                         type: ActionType.AddRoomIds,

--- a/src/hooks/useExistingRooms.ts
+++ b/src/hooks/useExistingRooms.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { PublicPermissionAssignment, StreamPermission, UserPermissionAssignment } from 'streamr-client'
+import { StreamPermission } from 'streamr-client'
 import { ActionType, useDispatch, useStore } from '../components/Store'
 import { StorageKey } from '../utils/types'
 import intersection from 'lodash/intersection'
@@ -63,8 +63,8 @@ export default function useExistingRooms() {
                         permission: StreamPermission.SUBSCRIBE,
                         allowPublic: true,
                     })
-                    
-                    if (!hasPermission && metadata.privacy !== 'public' ) {
+
+                    if (!hasPermission && metadata.privacy !== 'public') {
                         selfInviteStreams.push(stream.id)
                     }
                     remoteRoomIds.push(stream.id)

--- a/src/hooks/useInviterSelf.ts
+++ b/src/hooks/useInviterSelf.ts
@@ -46,9 +46,7 @@ export default function useInviterSelf(): Inviter {
                 if (includePublicPermissions) {
                     assignments.push({
                         public: true as true,
-                        permissions: [
-                            StreamPermission.SUBSCRIBE
-                        ],
+                        permissions: [StreamPermission.SUBSCRIBE],
                     })
                 }
                 return {

--- a/src/hooks/useSetPublicPermissions.ts
+++ b/src/hooks/useSetPublicPermissions.ts
@@ -1,0 +1,19 @@
+import { useCallback } from 'react'
+import { Stream, StreamPermission } from 'streamr-client'
+
+type Options = {
+    stream: Stream
+    permissions: StreamPermission[]
+}
+
+export default function useSetPublicPermissions(): ({
+    permissions,
+    stream,
+}: Options) => Promise<void> {
+    return useCallback(async ({ permissions, stream }: Options) => {
+        await stream.grantPermissions({
+            public: true,
+            permissions,
+        })
+    }, [])
+}

--- a/src/hooks/useSetPublicPermissions.ts
+++ b/src/hooks/useSetPublicPermissions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { Stream, StreamPermission } from 'streamr-client'
+import { useStore } from '../components/Store'
 
 type Options = {
     stream: Stream
@@ -10,10 +11,23 @@ export default function useSetPublicPermissions(): ({
     permissions,
     stream,
 }: Options) => Promise<void> {
-    return useCallback(async ({ permissions, stream }: Options) => {
-        await stream.grantPermissions({
-            public: true,
-            permissions,
-        })
-    }, [])
+    const { metamaskStreamrClient } = useStore()
+    return useCallback(
+        async ({ permissions, stream }: Options) => {
+            if (!metamaskStreamrClient) {
+                throw new Error('No metamask streamr client found')
+            }
+
+            await metamaskStreamrClient.setPermissions({
+                streamId: stream.id,
+                assignments: [
+                    {
+                        public: true,
+                        permissions,
+                    },
+                ],
+            })
+        },
+        [metamaskStreamrClient]
+    )
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -15,6 +15,7 @@ export type MessagePayload = {
 export type RoomMetadata = {
     name: string
     createdAt: number
+    privacy: 'private' | 'viewonly' | 'public'
 }
 
 export type ChatState = {


### PR DESCRIPTION
Implement the functionality behind [FRONT-920](https://github.com/streamr-dev/chat/pull/112)
- Create a "private" room: permissions for publish and subscribe on the delegated wallet, requires invitation to join
- Create a "view only" room: public permissions on subscribe and publish handled as in "private" rooms, via invites
- Create a "public" room: room with publish and subscribe publish permissions

The metadata of rooms, contained as a stringified json in `stream.description` now includes the `privacy` flag to ease identifying the type of room, since with permissions alone and the delegated wallets it's hard to distinguish easily view-only from public rooms