### PR TITLE
[FRONT-941] Edit and options menu should be disabled when there is no room selected

### DIFF
--- a/src/components/pages/Chat/RoomHeader.tsx
+++ b/src/components/pages/Chat/RoomHeader.tsx
@@ -80,7 +80,7 @@ function UnstyledRoomHeader({ className }: Props) {
                             <span>Save</span>
                         </RoomAction>
                     </>
-                ) : (
+                ) : roomId ? (
                     <>
                         <RoomAction
                             type="button"
@@ -95,7 +95,7 @@ function UnstyledRoomHeader({ className }: Props) {
                         </RoomAction>
                         <RoomDropdown />
                     </>
-                )}
+                ) : null}
             </Collection>
         </form>
     )


### PR DESCRIPTION
Checking `roomId` on the RoomHeader component to display or hide the pencil and three dots icons