### PR TITLE
[FRONT-939] Load recent images from local storage

### DIFF
--- a/src/components/RoomDropdown/MemberOptions.tsx
+++ b/src/components/RoomDropdown/MemberOptions.tsx
@@ -10,6 +10,7 @@ import { useLocalStorage } from '../../hooks/useLocalStorage'
 import useRevoker from '../../hooks/useRevoker'
 import { ActionType, useDispatch, useStore } from '../Store'
 import getRoomMembersFromStream from '../../getters/getRoomMembersFromStream'
+import getIdenticon from '../../getters/getIdenticon'
 
 const Root = styled.div`
     padding: 15px 0px;
@@ -32,7 +33,7 @@ const Subtitle = styled.span`
 const MemberIcon = styled.div`
     height: 3rem;
     width: 3rem;
-    background-color: #cdcfd1;
+    background-color: #fff;
     border-radius: 50%;
     margin: 0px 20px;
 `
@@ -78,6 +79,17 @@ const DropDownListContainer = styled.div`
     top: 45px;
     right: 0px;
     z-index: 100;
+`
+
+const AvatarWrap = styled.div`
+    padding: 0.5rem;
+`
+
+const Avatar = styled.img`
+    background-color: #f1f4f7;
+    display: block;
+    height: 2rem;
+    width: 2rem;
 `
 
 const DropDownList = styled.div`
@@ -163,7 +175,15 @@ const UnstyledMemberOptions = ({ address }: any) => {
     }
     return (
         <Root>
-            <MemberIcon />
+            <MemberIcon>
+                <AvatarWrap>
+                    <Avatar
+                        src={`data:image/png;base64,${getIdenticon(address)}`}
+                        alt={address}
+                    />
+                </AvatarWrap>
+            </MemberIcon>
+
             <MemberContainer>
                 {editing ? (
                     <MemberInput

--- a/src/components/pages/Chat/Message.tsx
+++ b/src/components/pages/Chat/Message.tsx
@@ -3,6 +3,7 @@ import Identicon from 'identicon.js'
 import DateTooltip from './DateTooltip'
 import type { MessagePayload } from '../../../utils/types'
 import { useStore } from '../../Store'
+import getIdenticon from '../../../getters/getIdenticon'
 
 type Props = {
     className?: string
@@ -70,10 +71,7 @@ const UnstyledMessage = ({
             {incoming && (
                 <AvatarWrap>
                     <Avatar
-                        src={`data:image/png;base64,${new Identicon(
-                            sender,
-                            AVATAR_OPTIONS
-                        ).toString()}`}
+                        src={`data:image/png;base64,${getIdenticon(sender)}`}
                         alt={sender}
                     />
                 </AvatarWrap>

--- a/src/components/pages/Chat/RoomItem.tsx
+++ b/src/components/pages/Chat/RoomItem.tsx
@@ -3,9 +3,8 @@ import type { Props as SidebarItemProps } from './SidebarItem'
 import SidebarItem from './SidebarItem'
 import type { MessagePayload } from '../../../utils/types'
 import { ActionType, useDispatch, useStore } from '../../Store'
-import Identicon from 'identicon.js'
 import useRoomName from '../../../hooks/useRoomName'
-import { keccak256 } from 'js-sha3'
+import getIdenticon from '../../../getters/getIdenticon'
 
 type Props = SidebarItemProps & {
     id: string
@@ -30,11 +29,6 @@ const Avatar = styled.img`
     height: 2rem;
     width: 2rem;
 `
-
-const AVATAR_OPTIONS: any = {
-    size: 32,
-    background: [255, 255, 255, 255],
-}
 
 function UnstyledRoomItem({ id, ...props }: Props) {
     const { roomId, recentMessages } = useStore()
@@ -62,10 +56,7 @@ function UnstyledRoomItem({ id, ...props }: Props) {
             icon={
                 <AvatarWrap>
                     <Avatar
-                        src={`data:image/png;base64,${new Identicon(
-                            keccak256(id),
-                            AVATAR_OPTIONS
-                        ).toString()}`}
+                        src={`data:image/png;base64,${getIdenticon(id)}`}
                         alt={id}
                     />
                 </AvatarWrap>

--- a/src/getters/getIdenticon.ts
+++ b/src/getters/getIdenticon.ts
@@ -18,5 +18,5 @@ export default function getIdenticon(seed: string): string {
     const identicon = new Identicon(hash, AVATAR_OPTIONS).toString()
     localStorage.setItem(LocalStorageKey, identicon)
 
-    return identicon.toString()
+    return identicon
 }

--- a/src/getters/getIdenticon.ts
+++ b/src/getters/getIdenticon.ts
@@ -1,0 +1,22 @@
+import Identicon from 'identicon.js'
+import { keccak256 } from 'js-sha3'
+
+const AVATAR_OPTIONS: any = {
+    size: 32,
+    background: [255, 255, 255, 255],
+}
+
+export default function getIdenticon(seed: string): string {
+    const hash = keccak256(seed)
+    const LocalStorageKey = `identicon:${hash}`
+    const localIdenticon = localStorage.getItem(LocalStorageKey)
+
+    if (localIdenticon) {
+        return localIdenticon
+    }
+
+    const identicon = new Identicon(hash, AVATAR_OPTIONS).toString()
+    localStorage.setItem(LocalStorageKey, identicon)
+
+    return identicon.toString()
+}


### PR DESCRIPTION
Added the `getIdenticon(seed: string)` getter to replace the raw calls to `Identicon`. 
- If the identicon's key, formated as `identicon:keccak256(${GIVEN_IDENTICON_SEED})` is found on `localStorage` it will be returned as a string
- Otherwise, the same process for Identicon generation happens and the resulting string is stored in `localStorage` under the lookup key.

Replaced identicons in `roomItem` and `message` components, and added the getter into the `roomMembers` member list view.