### PR TITLE
Minor UI fencing & type coverage upgrade for RoomPrivacy

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -2,7 +2,7 @@ name: Site
 on:
   push:
     branches:
-      - development
+      - master
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -2,7 +2,7 @@ name: Site
 on:
   push:
     branches:
-      - master
+      - development
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/src/components/RoomDropdown/index.tsx
+++ b/src/components/RoomDropdown/index.tsx
@@ -229,7 +229,7 @@ const RoomDropdown = ({ button }: Props) => {
                 {isOpen && (
                     <DropDownListContainer ref={ref}>
                         <DropDownList>
-                            {roomPrivacy !== RoomPrivacy.Public ? (
+                            {roomPrivacy !== RoomPrivacy.Public && (
                                 <>
                                     <ListItem
                                         onClick={() =>
@@ -249,7 +249,7 @@ const RoomDropdown = ({ button }: Props) => {
                                     </ListItem>
                                     <hr></hr>
                                 </>
-                            ) : null}
+                            )}
                             <ListItem>
                                 <CopyToClipboard text={roomId!}>
                                     <div>

--- a/src/components/RoomDropdown/index.tsx
+++ b/src/components/RoomDropdown/index.tsx
@@ -19,6 +19,8 @@ import getRoomMembersFromStream from '../../getters/getRoomMembersFromStream'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import useDeleteRoom from '../../hooks/useDeleteRoom'
 import useGetOnlineRoomMembers from '../../hooks/useGetOnlineRoomMembers'
+import getRoomMetadata from '../../getters/getRoomMetadata'
+import { RoomPrivacy } from '../../utils/types'
 
 type Props = {
     button?: any
@@ -136,17 +138,20 @@ const RoomDropdown = ({ button }: Props) => {
 
     const {
         roomId,
+        account,
         session: { streamrClient },
     } = useStore()
 
     const [members, setMembers] = useState(Array<string>())
+    const [isRoomOwner, setIsRoomOwner] = useState(false)
+    const [roomPrivacy, setRoomPrivacy] = useState<RoomPrivacy>()
     const getOnlineRoomMembers = useGetOnlineRoomMembers()
     const [onlineMembers, setOnlineMembers] = useState(Array<string>())
     useEffect(() => {
         let mounted = true
 
         const fn = async () => {
-            if (!streamrClient || !roomId) {
+            if (!streamrClient || !roomId || !account) {
                 return
             }
 
@@ -157,12 +162,21 @@ const RoomDropdown = ({ button }: Props) => {
                 return
             }
 
+            // parse and assign the privacy
+            const { privacy } = getRoomMetadata(stream.description!)
+            setRoomPrivacy(privacy)
+
+            // check if owner
+            setIsRoomOwner(stream.id.includes(account))
+
+            // get room members
             const members = await getRoomMembersFromStream(stream)
             if (!mounted) {
                 return
             }
             setMembers(members)
 
+            // get online members
             const onlineMembers = await getOnlineRoomMembers({
                 streamId: stream.id,
             })
@@ -177,7 +191,7 @@ const RoomDropdown = ({ button }: Props) => {
         return () => {
             mounted = false
         }
-    }, [roomId, streamrClient, getOnlineRoomMembers])
+    }, [account, getOnlineRoomMembers, roomId, streamrClient])
 
     useEffect(() => {
         function handleClickOutside(event: any) {
@@ -215,17 +229,27 @@ const RoomDropdown = ({ button }: Props) => {
                 {isOpen && (
                     <DropDownListContainer ref={ref}>
                         <DropDownList>
-                            <ListItem
-                                onClick={() => void setMemberModalIsOpen(true)}
-                            >
-                                <AddMemberIcon />
-                                Add member
-                            </ListItem>
-                            <ListItem onClick={() => void setModalIsOpen(true)}>
-                                <EditMembersIcon />
-                                Edit members
-                            </ListItem>
-                            <hr></hr>
+                            {roomPrivacy !== RoomPrivacy.Public ? (
+                                <>
+                                    <ListItem
+                                        onClick={() =>
+                                            void setMemberModalIsOpen(true)
+                                        }
+                                    >
+                                        <AddMemberIcon />
+                                        Add member
+                                    </ListItem>
+                                    <ListItem
+                                        onClick={() =>
+                                            void setModalIsOpen(true)
+                                        }
+                                    >
+                                        <EditMembersIcon />
+                                        Edit members
+                                    </ListItem>
+                                    <hr></hr>
+                                </>
+                            ) : null}
                             <ListItem>
                                 <CopyToClipboard text={roomId!}>
                                     <div>
@@ -235,10 +259,12 @@ const RoomDropdown = ({ button }: Props) => {
                                 </CopyToClipboard>
                             </ListItem>
                             <hr></hr>
-                            <ListItem onClick={clickDeleteRoom}>
-                                <DeleteIcon />
-                                Delete room
-                            </ListItem>
+                            {isRoomOwner ? (
+                                <ListItem onClick={clickDeleteRoom}>
+                                    <DeleteIcon />
+                                    Delete room
+                                </ListItem>
+                            ) : null}
                         </DropDownList>
                     </DropDownListContainer>
                 )}

--- a/src/components/pages/Chat/AddRoomModal/PrivacySelect.tsx
+++ b/src/components/pages/Chat/AddRoomModal/PrivacySelect.tsx
@@ -5,24 +5,25 @@ import publicIcon from './public.svg'
 import viewOnlyIcon from './viewonly.svg'
 import privateIcon from './private.svg'
 import checkIcon from './check.svg'
+import { RoomPrivacy } from '../../../../utils/types'
 
 const options = [
     {
         label: 'Private',
         subLabel: 'Only invited members can post and view messages',
-        value: 'private',
+        value: RoomPrivacy.Private,
         icon: privateIcon,
     },
     {
         label: 'View only',
         subLabel: 'Anyone can view other messages',
-        value: 'viewonly',
+        value: RoomPrivacy.ViewOnly,
         icon: viewOnlyIcon,
     },
     {
         label: 'Public',
         subLabel: 'Anyone can post and view other messages',
-        value: 'public',
+        value: RoomPrivacy.Public,
         icon: publicIcon,
     },
 ]

--- a/src/components/pages/Chat/MessageTransmitter.tsx
+++ b/src/components/pages/Chat/MessageTransmitter.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext } from 'react'
 import useInviter from '../../../hooks/useInviter'
-import { MessageType } from '../../../utils/types'
+import { MessageType, RoomPrivacy } from '../../../utils/types'
 import { useStore } from '../../Store'
 import { v4 as uuidv4 } from 'uuid'
 import MessageAggregator from './MessageAggregator'
@@ -136,7 +136,7 @@ export default function MessageTransmitter({ children }: Props) {
                     case Command.New:
                         await createRoom({
                             roomName: arg,
-                            privacy: 'private',
+                            privacy: RoomPrivacy.Private,
                         })
                         return
                     case Command.Members:
@@ -252,7 +252,7 @@ export default function MessageTransmitter({ children }: Props) {
                 try {
                     const stream = await streamrClient.getStream(streamId)
                     const { privacy } = getRoomMetadata(stream.description!)
-                    if (privacy === 'private') {
+                    if (privacy === RoomPrivacy.Private) {
                         await streamrClient.publish(
                             streamId,
                             {

--- a/src/getters/getRoomMembersFromStream.ts
+++ b/src/getters/getRoomMembersFromStream.ts
@@ -4,6 +4,7 @@ import {
     StreamPermission,
     UserPermissionQuery,
 } from 'streamr-client'
+import { RoomPrivacy } from '../utils/types'
 import getRoomMetadata from './getRoomMetadata'
 
 const isUserPermissionQuery = (
@@ -23,7 +24,7 @@ export default async function getRoomMembersFromStream(
 
     // on public streams return an empty array
 
-    if (metadata.privacy === 'public') {
+    if (metadata.privacy === RoomPrivacy.Public) {
         return members
     }
 
@@ -32,11 +33,11 @@ export default async function getRoomMembersFromStream(
             isUserPermissionQuery(assignment) &&
             // on read-only streams return those with PUBLISH permission
 
-            ((metadata.privacy === 'viewonly' &&
+            ((metadata.privacy === RoomPrivacy.ViewOnly &&
                 assignment.permissions.includes(StreamPermission.PUBLISH)) ||
                 // on private streams return those with GRANT permission
 
-                (metadata.privacy === 'private' &&
+                (metadata.privacy === RoomPrivacy.Private &&
                     assignment.permissions.includes(StreamPermission.GRANT)) ||
                 assignment.permissions.includes(StreamPermission.SUBSCRIBE))
         ) {

--- a/src/hooks/useCreateRoom.ts
+++ b/src/hooks/useCreateRoom.ts
@@ -1,13 +1,13 @@
 import { useCallback } from 'react'
 import { StreamPermission, STREAMR_STORAGE_NODE_GERMANY } from 'streamr-client'
 import { ActionType, useDispatch, useStore } from '../components/Store'
-import { RoomMetadata } from '../utils/types'
+import { RoomMetadata, RoomPrivacy } from '../utils/types'
 import useInviterSelf from './useInviterSelf'
 import useSetPublicPermissions from './useSetPublicPermissions'
 
 type Options = {
     roomName: string
-    privacy: 'private' | 'viewonly' | 'public'
+    privacy: RoomPrivacy
     storageEnabled?: boolean
 }
 export default function useCreateRoom(): ({
@@ -67,19 +67,19 @@ export default function useCreateRoom(): ({
             console.info(`Created stream ${stream.id}`)
 
             switch (privacy) {
-                case 'private':
+                case RoomPrivacy.Private:
                     await inviteSelf({
                         streamIds: [stream.id],
                     })
                     break
 
-                case 'viewonly':
+                case RoomPrivacy.ViewOnly:
                     await inviteSelf({
                         streamIds: [stream.id],
                         includePublicPermissions: true,
                     })
                     break
-                case 'public':
+                case RoomPrivacy.Public:
                     await setPublicPermissions({
                         permissions: [
                             StreamPermission.PUBLISH,

--- a/src/hooks/useExistingRooms.ts
+++ b/src/hooks/useExistingRooms.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { StreamPermission } from 'streamr-client'
 import { ActionType, useDispatch, useStore } from '../components/Store'
-import { StorageKey } from '../utils/types'
+import { RoomPrivacy, StorageKey } from '../utils/types'
 import intersection from 'lodash/intersection'
 import useInviterSelf from './useInviterSelf'
 import getRoomMetadata from '../getters/getRoomMetadata'
@@ -64,7 +64,10 @@ export default function useExistingRooms() {
                         allowPublic: true,
                     })
 
-                    if (!hasPermission && metadata.privacy !== 'public') {
+                    if (
+                        !hasPermission &&
+                        metadata.privacy !== RoomPrivacy.Public
+                    ) {
                         selfInviteStreams.push(stream.id)
                     }
                     remoteRoomIds.push(stream.id)

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -13,10 +13,15 @@ export type MessagePayload = {
     type: MessageType
 }
 
+export enum RoomPrivacy {
+    Private = 'private',
+    ViewOnly = 'viewonly',
+    Public = 'public',
+}
 export type RoomMetadata = {
     name: string
     createdAt: number
-    privacy: 'private' | 'viewonly' | 'public'
+    privacy: RoomPrivacy
 }
 
 export type ChatState = {


### PR DESCRIPTION
- cleaned mid-there work already covered in the new tickets
- added fencing around addMembers/editMembers on public rooms
- added fencing around deleting rooms for non-owners
- moved RoomPrivacy into it's own enum to avoid comparing strings
