### PR TITLE
[FRONT-1044] Hide delegated accounts from edit member modal

### DIFF
--- a/src/components/modals/EditMembersModal.tsx
+++ b/src/components/modals/EditMembersModal.tsx
@@ -248,6 +248,9 @@ function Item({
     permissions,
     ...props
 }: ItemProps) {
+    if (accountType === AccountType.Delegated) {
+        return null
+    }
     const [memberMenuOpen, setMemberMenuOpen] = useState<boolean>(false)
 
     const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLButtonElement | null>(null)
@@ -447,8 +450,6 @@ function Item({
                                                 <>
                                                     {accountType === AccountType.Main
                                                         ? '[Main Account] '
-                                                        : accountType === AccountType.Delegated
-                                                        ? '[Delegated Account] '
                                                         : accountType === AccountType.Unset
                                                         ? '[Unset Account] '
                                                         : null}

--- a/src/components/modals/EditMembersModal.tsx
+++ b/src/components/modals/EditMembersModal.tsx
@@ -202,22 +202,24 @@ export default function EditMembersModal({ open, canModifyMembers = false, ...pr
                         </div>
                     ) : (
                         <>
-                            {members.map(({ address, permissions, accountType }) => (
-                                <Item
-                                    key={address}
-                                    onMenuToggle={onMenuToggle}
-                                    address={address}
-                                    canBeDeleted={canModifyMembers}
-                                    onDeleteClick={onDeleteClick}
-                                    isCurrentAccount={isSameAddress(address, account)}
-                                    isCurrentDelegatedAccount={isSameAddress(
-                                        address,
-                                        delegatedAccount
-                                    )}
-                                    permissions={permissions}
-                                    accountType={accountType}
-                                />
-                            ))}
+                            {members.map(({ address, permissions, accountType }) => {
+                                return accountType !== AccountType.Delegated ? (
+                                    <Item
+                                        key={address}
+                                        onMenuToggle={onMenuToggle}
+                                        address={address}
+                                        canBeDeleted={canModifyMembers}
+                                        onDeleteClick={onDeleteClick}
+                                        isCurrentAccount={isSameAddress(address, account)}
+                                        isCurrentDelegatedAccount={isSameAddress(
+                                            address,
+                                            delegatedAccount
+                                        )}
+                                        permissions={permissions}
+                                        accountType={accountType}
+                                    />
+                                ) : null
+                            })}
                         </>
                     )}
                 </div>
@@ -248,9 +250,6 @@ function Item({
     permissions,
     ...props
 }: ItemProps) {
-    if (accountType === AccountType.Delegated) {
-        return null
-    }
     const [memberMenuOpen, setMemberMenuOpen] = useState<boolean>(false)
 
     const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLButtonElement | null>(null)


### PR DESCRIPTION
Added a check for the type `AccountType.Delegated` that returns null, effectively hiding the delegated accounts from the edit members modal