### PR TITLE
[FRONT-1043] Invited members should have increased permissions

### DIFF
--- a/src/features/member/sagas/acceptInvite.saga.ts
+++ b/src/features/member/sagas/acceptInvite.saga.ts
@@ -18,7 +18,12 @@ function* onAcceptInviteAction({
                 },
                 {
                     user: member,
-                    permissions: [StreamPermission.GRANT, StreamPermission.EDIT],
+                    permissions: [
+                        StreamPermission.GRANT,
+                        StreamPermission.EDIT,
+                        StreamPermission.PUBLISH,
+                        StreamPermission.SUBSCRIBE,
+                    ],
                 },
             ],
             {

--- a/src/features/member/sagas/add.saga.tsx
+++ b/src/features/member/sagas/add.saga.tsx
@@ -101,11 +101,7 @@ function* onAddAction({
             [
                 {
                     user,
-                    permissions: [
-                        StreamPermission.GRANT,
-                        StreamPermission.PUBLISH,
-                        StreamPermission.SUBSCRIBE,
-                    ],
+                    permissions: [StreamPermission.GRANT, StreamPermission.SUBSCRIBE],
                 },
             ],
             {

--- a/src/features/member/sagas/add.saga.tsx
+++ b/src/features/member/sagas/add.saga.tsx
@@ -101,7 +101,11 @@ function* onAddAction({
             [
                 {
                     user,
-                    permissions: [StreamPermission.GRANT],
+                    permissions: [
+                        StreamPermission.GRANT,
+                        StreamPermission.PUBLISH,
+                        StreamPermission.SUBSCRIBE,
+                    ],
                 },
             ],
             {

--- a/src/hooks/useListenForInvitesEffect.ts
+++ b/src/hooks/useListenForInvitesEffect.ts
@@ -66,10 +66,14 @@ export default function useListenForInvitesEffect(
 
             const canPub = publishExpirationTimestampSeconds.gt(now)
 
-            if (!(canPub && canSub && canGrant)) {
+            if (
+                canPub ||
+                canEdit ||
+                canDelete || // irrelevant to invites
+                !(canSub && canGrant) // both required for a potential invite
+            ) {
                 return
             }
-            // It's an invite.
 
             if (!isSameAddress(userAddress, address) || !streamId.includes(Prefix.Room)) {
                 // Irrelevant. Skipping.

--- a/src/hooks/useListenForInvitesEffect.ts
+++ b/src/hooks/useListenForInvitesEffect.ts
@@ -66,10 +66,10 @@ export default function useListenForInvitesEffect(
 
             const canPub = publishExpirationTimestampSeconds.gt(now)
 
-            if (canEdit || canDelete || canPub || canSub) {
-                // It's not an invite. Invite means grant-only.
+            if (!(canPub && canSub && canGrant)) {
                 return
             }
+            // It's an invite.
 
             if (!isSameAddress(userAddress, address) || !streamId.includes(Prefix.Room)) {
                 // Irrelevant. Skipping.

--- a/src/utils/waitForPermissions.ts
+++ b/src/utils/waitForPermissions.ts
@@ -11,7 +11,6 @@ export default function waitForPermissions(
 ) {
     return retry(30, 1000, function* () {
         const assignments: PermissionAssignment[] = yield streamrClient.getPermissions(roomId)
-
         if (!validator(assignments)) {
             throw new Error('Validation failed')
         }


### PR DESCRIPTION
Invites now grant `GRANT`, `PUBLISH`, `SUBSCRIBE` permissions to the metamask account. `EDIT` is added upon delegation.