### PR TITLE
FRONT-1264: Network switch fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "private": true,
     "version": "0.0.0",
     "scripts": {
+        "check": "tsc --noEmit && npm run lint && npm test",
         "build": "tsc && vite build",
         "lint": "eslint . --ext .ts,.tsx",
         "preview": "vite preview",

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -1,14 +1,12 @@
-import { useEffect } from 'react'
 import tw from 'twin.macro'
 import Page from '$/components/Page'
 import Conversation from '$/components/Conversation'
 import Nav from '$/components/Nav'
-import { useWalletAccount, useWalletClient } from '$/features/wallet/hooks'
+import { useWalletAccount } from '$/features/wallet/hooks'
 import UtilityButton from '$/components/UtilityButton'
 import Text from '$/components/Text'
 import useSelectedRoom from '$/hooks/useSelectedRoom'
 import { useDispatch } from 'react-redux'
-import { RoomsAction } from '$/features/rooms'
 import useListenForInvitesEffect from '$/hooks/useListenForInvitesEffect'
 import { RoomAction } from '$/features/room'
 import { Flag } from '$/features/flag/types'
@@ -34,31 +32,11 @@ export default function ChatPage() {
 
     const account = useWalletAccount()
 
-    const streamrClient = useWalletClient()
-
-    useEffect(() => {
-        if (!account || !streamrClient) {
-            return
-        }
-
-        dispatch(
-            RoomsAction.fetch({
-                requester: account,
-                streamrClient,
-            })
-        )
-    }, [dispatch, account, streamrClient])
-
     useListenForInvitesEffect(account, (roomId, invitee) => {
-        if (!streamrClient) {
-            return
-        }
-
         dispatch(
             RoomAction.registerInvite({
                 roomId,
                 invitee,
-                streamrClient,
                 fingerprint: Flag.isInviteBeingRegistered(roomId, invitee),
             })
         )

--- a/src/components/Conversation/ConversationHeader.tsx
+++ b/src/components/Conversation/ConversationHeader.tsx
@@ -11,7 +11,7 @@ import {
     useSelectedRoomId,
     useTransientRoomName,
 } from '$/features/room/hooks'
-import { useWalletAccount, useWalletClient } from '$/features/wallet/hooks'
+import { useWalletAccount } from '$/features/wallet/hooks'
 import useCopy from '$/hooks/useCopy'
 import useSelectedRoom from '$/hooks/useSelectedRoom'
 import AddMemberIcon from '$/icons/AddMemberIcon'
@@ -116,10 +116,8 @@ export default function ConversationHeader({
 
     const { copy } = useCopy()
 
-    const streamrClient = useWalletClient()
-
     function onRenameSubmit() {
-        if (!selectedRoomId || !account || !streamrClient) {
+        if (!selectedRoomId || !account) {
             return
         }
 
@@ -128,21 +126,19 @@ export default function ConversationHeader({
                 roomId: selectedRoomId,
                 name: transientRoomName,
                 requester: account,
-                streamrClient,
                 fingerprint: Flag.isPersistingRoomName(selectedRoomId),
             })
         )
     }
 
     useEffect(() => {
-        if (!selectedRoomId || !streamrClient) {
+        if (!selectedRoomId) {
             return
         }
 
         dispatch(
             RoomAction.getPrivacy({
                 roomId: selectedRoomId,
-                streamrClient,
                 fingerprint: Flag.isGettingPrivacy(selectedRoomId),
             })
         )
@@ -455,12 +451,11 @@ export default function ConversationHeader({
                                     <MenuButtonItem
                                         icon={<PinIcon css={tw`w-2.5`} />}
                                         onClick={() => {
-                                            if (selectedRoomId && account && streamrClient) {
+                                            if (selectedRoomId && account) {
                                                 dispatch(
                                                     RoomAction.unpin({
                                                         roomId: selectedRoomId,
                                                         requester: account,
-                                                        streamrClient,
                                                         fingerprint: Flag.isRoomBeingUnpinned(
                                                             selectedRoomId,
                                                             account
@@ -494,12 +489,11 @@ export default function ConversationHeader({
                                     <MenuButtonItem
                                         icon={<DeleteIcon />}
                                         onClick={() => {
-                                            if (account && selectedRoomId && streamrClient) {
+                                            if (account && selectedRoomId) {
                                                 dispatch(
                                                     RoomAction.delete({
                                                         roomId: selectedRoomId,
                                                         requester: account,
-                                                        streamrClient,
                                                         fingerprint:
                                                             Flag.isRoomBeingDeleted(selectedRoomId),
                                                     })

--- a/src/components/RoomButton.tsx
+++ b/src/components/RoomButton.tsx
@@ -4,7 +4,7 @@ import tw from 'twin.macro'
 import { PermissionsAction } from '$/features/permissions'
 import { RoomAction } from '$/features/room'
 import { IRoom, RoomId } from '$/features/room/types'
-import { useWalletAccount, useWalletClient } from '$/features/wallet/hooks'
+import { useWalletAccount } from '$/features/wallet/hooks'
 import useIntercept from '$/hooks/useIntercept'
 import useJustInvited from '$/hooks/useJustInvited'
 import useRecentMessage from '$/hooks/useRecentMessage'
@@ -48,10 +48,8 @@ export default function RoomButton({ room, active, ...props }: Props) {
 
     const requester = useWalletAccount()
 
-    const streamrClient = useWalletClient()
-
     useEffect(() => {
-        if (!requester || !streamrClient) {
+        if (!requester) {
             return
         }
 
@@ -59,7 +57,6 @@ export default function RoomButton({ room, active, ...props }: Props) {
             RoomAction.sync({
                 roomId: id,
                 requester,
-                streamrClient,
                 fingerprint: Flag.isSyncingRoom(id),
             })
         )
@@ -70,7 +67,7 @@ export default function RoomButton({ room, active, ...props }: Props) {
     const address = useWalletAccount()
 
     useEffect(() => {
-        if (!address || !streamrClient) {
+        if (!address) {
             return
         }
 
@@ -78,11 +75,10 @@ export default function RoomButton({ room, active, ...props }: Props) {
             PermissionsAction.fetchPermissions({
                 roomId: id,
                 address,
-                streamrClient,
                 fingerprint: Flag.isFetchingAllPermissions(id, address),
             })
         )
-    }, [id, address, streamrClient])
+    }, [id, address])
 
     const justInvited = useJustInvited(id, address)
 
@@ -162,8 +158,6 @@ export function PassiveRoomButton({
 
     const account = useWalletAccount()
 
-    const streamrClient = useWalletClient()
-
     return (
         <SidebarButton
             {...props}
@@ -176,7 +170,7 @@ export function PassiveRoomButton({
 
                 onClick?.(e)
 
-                if (!account || !streamrClient) {
+                if (!account) {
                     return
                 }
 
@@ -185,7 +179,6 @@ export function PassiveRoomButton({
                         roomId,
                         account,
                         fingerprint: Flag.isPreselectingRoom(roomId),
-                        streamrClient,
                     })
                 )
             }}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,7 +6,6 @@ import Text from '$/components/Text'
 import { Flag } from '$/features/flag/types'
 import { RoomAction } from '$/features/room'
 import { RoomId } from '$/features/room/types'
-import { useWalletClient } from '$/features/wallet/hooks'
 import useFlag from '$/hooks/useFlag'
 import useRooms from '$/hooks/useRooms'
 import useSearchResult from '$/hooks/useSearchResult'
@@ -147,8 +146,6 @@ interface SearchProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 function Search({ roomId, onRoomId, onGoBackButtonClick, ...props }: SearchProps) {
-    const streamrClient = useWalletClient()
-
     const dispatch = useDispatch()
 
     const isSearching = useFlag(Flag.isSearching())
@@ -161,14 +158,13 @@ function Search({ roomId, onRoomId, onGoBackButtonClick, ...props }: SearchProps
                     items-center
                 `}
                 onSubmit={() => {
-                    if (isBlank(roomId) || !streamrClient) {
+                    if (isBlank(roomId)) {
                         return
                     }
 
                     dispatch(
                         RoomAction.search({
                             roomId,
-                            streamrClient,
                             fingerprint: Flag.isSearching(),
                         })
                     )

--- a/src/components/modals/EditMembersModal.tsx
+++ b/src/components/modals/EditMembersModal.tsx
@@ -6,7 +6,7 @@ import { PermissionsAction } from '$/features/permissions'
 import useRoomMembers from '$/hooks/useRoomMembers'
 import useIsDetectingRoomMembers from '$/hooks/useIsDetectingRoomMembers'
 import { useSelectedRoomId } from '$/features/room/hooks'
-import { useWalletAccount, useWalletClient } from '$/features/wallet/hooks'
+import { useWalletAccount } from '$/features/wallet/hooks'
 import useCopy from '$/hooks/useCopy'
 import CopyIcon from '$/icons/CopyIcon'
 import ExternalLinkIcon from '$/icons/ExternalLinkIcon'
@@ -61,11 +61,9 @@ export default function EditMembersModal({
 
     const requester = useWalletAccount()
 
-    const streamrClient = useWalletClient()
-
     const onDeleteClick = useCallback(
         (member: Address) => {
-            if (!selectedRoomId || !requester || !streamrClient) {
+            if (!selectedRoomId || !requester) {
                 return
             }
 
@@ -74,12 +72,11 @@ export default function EditMembersModal({
                     roomId: selectedRoomId,
                     member,
                     requester,
-                    streamrClient,
                     fingerprint: Flag.isMemberBeingRemoved(selectedRoomId, member),
                 })
             )
         },
-        [dispatch, selectedRoomId, requester, streamrClient]
+        [dispatch, selectedRoomId, requester]
     )
 
     const members = useRoomMembers(selectedRoomId)

--- a/src/components/modals/RoomPropertiesModal.tsx
+++ b/src/components/modals/RoomPropertiesModal.tsx
@@ -17,7 +17,7 @@ import Submit from '../Submit'
 import Text from '../Text'
 import Toggle from '../Toggle'
 import Modal, { Props as ModalProps } from './Modal'
-import { useWalletAccount, useWalletClient } from '$/features/wallet/hooks'
+import { useWalletAccount } from '$/features/wallet/hooks'
 import { Flag } from '$/features/flag/types'
 import TextField from '$/components/TextField'
 import i18n from '$/utils/i18n'
@@ -53,12 +53,10 @@ export default function RoomPropertiesModal({
 
     const dispatch = useDispatch()
 
-    const streamrClient = useWalletClient()
-
     const requester = useWalletAccount()
 
     function onStorageToggleClick() {
-        if (!selectedRoomId || isStorageBusy || !requester || !streamrClient) {
+        if (!selectedRoomId || isStorageBusy || !requester) {
             return
         }
 
@@ -68,7 +66,6 @@ export default function RoomPropertiesModal({
                 address: STREAMR_STORAGE_NODE_GERMANY,
                 state: !isStorageEnabled,
                 requester,
-                streamrClient,
                 fingerprint: Flag.isTogglingStorageNode(
                     selectedRoomId,
                     STREAMR_STORAGE_NODE_GERMANY
@@ -78,14 +75,13 @@ export default function RoomPropertiesModal({
     }
 
     useEffect(() => {
-        if (!open || !selectedRoomId || !streamrClient) {
+        if (!open || !selectedRoomId) {
             return
         }
 
         dispatch(
             RoomAction.getStorageNodes({
                 roomId: selectedRoomId,
-                streamrClient,
                 fingerprint: Flag.isGettingStorageNodes(selectedRoomId),
             })
         )

--- a/src/features/permissions/index.ts
+++ b/src/features/permissions/index.ts
@@ -4,7 +4,6 @@ import { RoomId } from '$/features/room/types'
 import { Address, IFingerprinted, PreflightParams } from '$/types'
 import { createAction, createReducer } from '@reduxjs/toolkit'
 import { all } from 'redux-saga/effects'
-import type StreamrClient from 'streamr-client'
 import { StreamPermission } from 'streamr-client'
 
 const initialState: PermissionsState = {
@@ -13,9 +12,9 @@ const initialState: PermissionsState = {
 }
 
 export const PermissionsAction = {
-    detectRoomMembers: createAction<
-        IFingerprinted & { roomId: RoomId; streamrClient: StreamrClient }
-    >('permissions: detect room members'),
+    detectRoomMembers: createAction<IFingerprinted & { roomId: RoomId }>(
+        'permissions: detect room members'
+    ),
 
     setRoomMembers: createAction<{ roomId: RoomId; members: IMember[] }>(
         'permissions: set room members'
@@ -26,21 +25,18 @@ export const PermissionsAction = {
             PreflightParams & {
                 roomId: RoomId
                 member: Address
-                streamrClient: StreamrClient
             }
     >('permissions: remove member'),
 
-    addMember: createAction<
-        IFingerprinted &
-            PreflightParams & { roomId: RoomId; member: Address; streamrClient: StreamrClient }
-    >('permissions: add member'),
+    addMember: createAction<IFingerprinted & PreflightParams & { roomId: RoomId; member: Address }>(
+        'permissions: add member'
+    ),
 
     acceptInvite: createAction<
         IFingerprinted &
             PreflightParams & {
                 roomId: RoomId
                 member: Address
-                streamrClient: StreamrClient
             }
     >('permissions: accept invite'),
 
@@ -49,7 +45,6 @@ export const PermissionsAction = {
             PreflightParams & {
                 roomId: RoomId
                 delegatedAddress: Address
-                streamrClient: StreamrClient
             }
     >('permissions: promote delegated account'),
 
@@ -58,7 +53,6 @@ export const PermissionsAction = {
             PreflightParams & {
                 roomId: RoomId
                 delegatedAddress: Address
-                streamrClient: StreamrClient
             }
     >('permissions: token gated promote delegated account'),
 
@@ -67,14 +61,17 @@ export const PermissionsAction = {
             roomId: RoomId
             address: Address
             permission: StreamPermission
-            streamrClient: StreamrClient
         }
     >('permissions: fetch permission'),
 
-    fetchPermissions: createAction<
-        IFingerprinted & { roomId: RoomId; address: Address; streamrClient: StreamrClient }
-    >('permissions: fetch permissions'),
+    fetchPermissions: createAction<IFingerprinted & { roomId: RoomId; address: Address }>(
+        'permissions: fetch permissions'
+    ),
 
+    /**
+     * @FIXME: This shoule be named better. `cachePermissions` is better. Atm we don't know
+     * if it's gonna trigger some network traffic or not.
+     */
     setPermissions: createAction<{
         roomId: RoomId
         address: Address
@@ -90,7 +87,6 @@ export const PermissionsAction = {
         IFingerprinted &
             PreflightParams & {
                 roomId: RoomId
-                streamrClient: StreamrClient
             }
     >('permissions: allow anons publish'),
 }

--- a/src/features/permissions/sagas/helpers/acceptInvite.ts
+++ b/src/features/permissions/sagas/helpers/acceptInvite.ts
@@ -8,13 +8,11 @@ import { call } from 'redux-saga/effects'
 import { StreamPermission } from 'streamr-client'
 import delegationPreflight from '$/utils/delegationPreflight'
 import i18n from '$/utils/i18n'
-import getWalletProvider from '$/utils/getWalletProvider'
 
 export default function acceptInvite({
     roomId,
     member,
     requester,
-    streamrClient,
 }: ReturnType<typeof PermissionsAction.acceptInvite>['payload']) {
     return call(function* () {
         let tc: Controller | undefined
@@ -30,8 +28,6 @@ export default function acceptInvite({
                 title: i18n('acceptInviteToast.joiningTitle'),
                 type: ToastType.Processing,
             })
-
-            const provider = yield* getWalletProvider()
 
             yield setMultiplePermissions(
                 roomId,
@@ -51,9 +47,7 @@ export default function acceptInvite({
                     },
                 ],
                 {
-                    provider,
                     requester,
-                    streamrClient,
                 }
             )
 

--- a/src/features/permissions/sagas/helpers/addMember.tsx
+++ b/src/features/permissions/sagas/helpers/addMember.tsx
@@ -15,7 +15,6 @@ import { ToastType } from '$/components/Toast'
 import retoast from '$/features/toaster/helpers/retoast'
 import fetchStream from '$/utils/fetchStream'
 import i18n from '$/utils/i18n'
-import getWalletProvider from '$/utils/getWalletProvider'
 
 function isENS(user: any): boolean {
     return typeof user === 'string' && /\.eth$/.test(user)
@@ -64,7 +63,6 @@ export default function addMember({
     roomId,
     member,
     requester,
-    streamrClient,
 }: ReturnType<typeof PermissionsAction.addMember>['payload']) {
     return call(function* () {
         let tc: Controller | undefined
@@ -85,7 +83,7 @@ export default function addMember({
                 throw new Error('Address could not be resolved')
             }
 
-            const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+            const stream: Stream | null = yield fetchStream(roomId)
 
             if (!stream) {
                 throw new RoomNotFoundError(roomId)
@@ -97,8 +95,6 @@ export default function addMember({
                 throw new MemberExistsError(member)
             }
 
-            const provider = yield* getWalletProvider()
-
             yield setMultiplePermissions(
                 roomId,
                 [
@@ -108,9 +104,7 @@ export default function addMember({
                     },
                 ],
                 {
-                    provider,
                     requester,
-                    streamrClient,
                 }
             )
 

--- a/src/features/permissions/sagas/helpers/detectRoomMembers.ts
+++ b/src/features/permissions/sagas/helpers/detectRoomMembers.ts
@@ -12,13 +12,12 @@ import fetchStream from '$/utils/fetchStream'
 
 export default function detectRoomMembers({
     roomId,
-    streamrClient,
 }: ReturnType<typeof PermissionsAction.detectRoomMembers>['payload']) {
     return call(function* () {
         try {
             const members: IMember[] = []
 
-            const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+            const stream: Stream | null = yield fetchStream(roomId)
 
             if (!stream) {
                 throw new RoomNotFoundError(roomId)

--- a/src/features/permissions/sagas/helpers/fetchPermission.ts
+++ b/src/features/permissions/sagas/helpers/fetchPermission.ts
@@ -9,11 +9,10 @@ export default function fetchPermission({
     roomId,
     address,
     permission,
-    streamrClient,
 }: ReturnType<typeof PermissionsAction.fetchPermission>['payload']) {
     return call(function* () {
         try {
-            const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+            const stream: Stream | null = yield fetchStream(roomId)
 
             if (!stream) {
                 throw new RoomNotFoundError(roomId)

--- a/src/features/permissions/sagas/helpers/fetchPermissions.ts
+++ b/src/features/permissions/sagas/helpers/fetchPermissions.ts
@@ -1,16 +1,18 @@
 import { call, put } from 'redux-saga/effects'
-import { PermissionAssignment, StreamPermission } from 'streamr-client'
+import StreamrClient, { PermissionAssignment, StreamPermission } from 'streamr-client'
 import handleError from '$/utils/handleError'
 import isSameAddress from '$/utils/isSameAddress'
 import { PermissionsAction } from '$/features/permissions'
+import getTransactionalClient from '$/utils/getTransactionalClient'
 
 export default function fetchPermissions({
     roomId,
     address,
-    streamrClient,
 }: ReturnType<typeof PermissionsAction.fetchPermissions>['payload']) {
     return call(function* () {
         try {
+            const streamrClient: StreamrClient = yield getTransactionalClient()
+
             const assignments: PermissionAssignment[] = yield streamrClient.getPermissions(roomId)
 
             const permissions: { [permission: string]: boolean } = {

--- a/src/features/permissions/sagas/helpers/promoteDelegatedAccount.ts
+++ b/src/features/permissions/sagas/helpers/promoteDelegatedAccount.ts
@@ -1,24 +1,21 @@
 import { ToastType } from '$/components/Toast'
 import { PermissionsAction } from '$/features/permissions'
 import toast from '$/features/toaster/helpers/toast'
+import { selectWalletAccount } from '$/features/wallet/selectors'
 import { Address } from '$/types'
-import getWalletProvider from '$/utils/getWalletProvider'
 import handleError from '$/utils/handleError'
 import i18n from '$/utils/i18n'
 import setMultiplePermissions from '$/utils/setMultiplePermissions'
-import { call } from 'redux-saga/effects'
+import { call, select } from 'redux-saga/effects'
 import { StreamPermission } from 'streamr-client'
 
 export default function promoteDelegatedAccount({
     roomId,
     delegatedAddress,
-    streamrClient,
 }: ReturnType<typeof PermissionsAction.promoteDelegatedAccount>['payload']) {
     return call(function* () {
         try {
-            const requester: Address = yield streamrClient.getAddress()
-
-            const provider = yield* getWalletProvider()
+            const requester: Address = yield select(selectWalletAccount)
 
             yield setMultiplePermissions(
                 roomId,
@@ -29,9 +26,7 @@ export default function promoteDelegatedAccount({
                     },
                 ],
                 {
-                    provider,
                     requester,
-                    streamrClient,
                 }
             )
 

--- a/src/features/permissions/sagas/helpers/removeMember.tsx
+++ b/src/features/permissions/sagas/helpers/removeMember.tsx
@@ -16,7 +16,6 @@ export default function removeMember({
     roomId,
     member,
     requester,
-    streamrClient,
 }: ReturnType<typeof PermissionsAction.removeMember>['payload']) {
     return call(function* () {
         const displayName: string = yield getDisplayUsername(member)
@@ -45,9 +44,7 @@ export default function removeMember({
             }
 
             yield setMultiplePermissions(roomId, assignments, {
-                provider,
                 requester,
-                streamrClient,
             })
 
             yield toast({

--- a/src/features/permissions/sagas/lifecycle.saga.ts
+++ b/src/features/permissions/sagas/lifecycle.saga.ts
@@ -44,10 +44,10 @@ export default function* lifecycle() {
                 )
 
                 yield takeEveryUnique(PermissionsAction.join, function* ({ payload }) {
-                    const { requester, roomId, streamrClient } = payload
+                    const { requester, roomId } = payload
 
                     try {
-                        const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+                        const stream: Stream | null = yield fetchStream(roomId)
 
                         if (!stream) {
                             throw new RoomNotFoundError(roomId)

--- a/src/features/room/helpers/pinSticky.tsx
+++ b/src/features/room/helpers/pinSticky.tsx
@@ -4,7 +4,7 @@ import { stickyRoomIds } from '$/config.json'
 import { IPreference } from '$/features/preferences/types'
 import db from '$/utils/db'
 import { IRoom, RoomId } from '$/features/room/types'
-import StreamrClient, { Stream } from 'streamr-client'
+import { Stream } from 'streamr-client'
 import RoomNotFoundError from '$/errors/RoomNotFoundError'
 import handleError from '$/utils/handleError'
 import getRoomMetadata from '$/utils/getRoomMetadata'
@@ -18,12 +18,12 @@ import toaster from '$/features/toaster/helpers/toaster'
 import fetchStream from '$/utils/fetchStream'
 import i18n from '$/utils/i18n'
 
-function quietPin(roomId: RoomId, requester: Address, streamrClient: StreamrClient) {
+function quietPin(roomId: RoomId, requester: Address) {
     return call(function* () {
         try {
             const owner = requester.toLowerCase()
 
-            const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+            const stream: Stream | null = yield fetchStream(roomId)
 
             if (!stream) {
                 throw new RoomNotFoundError(roomId)
@@ -79,7 +79,6 @@ function quietPin(roomId: RoomId, requester: Address, streamrClient: StreamrClie
 
 export default function pinSticky({
     requester,
-    streamrClient,
 }: ReturnType<typeof RoomAction.pinSticky>['payload']) {
     return call(function* () {
         let t: Controller<typeof Toast> | undefined
@@ -111,7 +110,7 @@ export default function pinSticky({
                 const { id } = stickyRoomIds[i]
 
                 if (!ids.includes(id)) {
-                    const pinName: undefined | string = yield quietPin(id, requester, streamrClient)
+                    const pinName: undefined | string = yield quietPin(id, requester)
 
                     newIds.push(id)
 

--- a/src/features/room/helpers/preselect.tsx
+++ b/src/features/room/helpers/preselect.tsx
@@ -44,7 +44,6 @@ function selectRoom(roomId: RoomId, owner: Address) {
 export default function preselect({
     roomId,
     account,
-    streamrClient,
 }: ReturnType<typeof RoomAction.preselect>['payload']) {
     return call(function* () {
         if (!account) {
@@ -137,7 +136,7 @@ export default function preselect({
              * we're gonna make efforts to pin/bookmark it.
              */
 
-            const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+            const stream: Stream | null = yield fetchStream(roomId)
 
             if (!stream) {
                 throw new RoomNotFoundError(roomId)

--- a/src/features/room/helpers/search.ts
+++ b/src/features/room/helpers/search.ts
@@ -5,13 +5,10 @@ import handleError from '$/utils/handleError'
 import { call, put } from 'redux-saga/effects'
 import { Stream } from 'streamr-client'
 
-export default function search({
-    roomId,
-    streamrClient,
-}: ReturnType<typeof RoomAction.search>['payload']) {
+export default function search({ roomId }: ReturnType<typeof RoomAction.search>['payload']) {
     return call(function* () {
         try {
-            const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+            const stream: Stream | null = yield fetchStream(roomId)
 
             if (!stream) {
                 yield put(

--- a/src/features/room/index.ts
+++ b/src/features/room/index.ts
@@ -14,7 +14,6 @@ import sync from './sagas/sync.saga'
 import toggleStorageNode from './sagas/toggleStorageNode.saga'
 import { CachedTokenGate, IRoom, RoomId, RoomState } from './types'
 import setVisibility from '$/features/room/sagas/setVisibility.saga'
-import StreamrClient from 'streamr-client'
 import unpin from '$/features/room/sagas/unpin.saga'
 
 const initialState: RoomState = {
@@ -51,7 +50,6 @@ export const RoomAction = {
         IFingerprinted &
             PreflightParams & {
                 roomId: RoomId
-                streamrClient: StreamrClient
             }
     >('room: delete'),
 
@@ -62,7 +60,6 @@ export const RoomAction = {
             PreflightParams & {
                 roomId: RoomId
                 name: string
-                streamrClient: StreamrClient
             }
     >('room: rename'),
 
@@ -74,17 +71,12 @@ export const RoomAction = {
         IFingerprinted & {
             roomId: RoomId
             account: OptionalAddress
-            streamrClient: StreamrClient
         }
     >('room: preselect'),
 
-    sync: createAction<
-        IFingerprinted & { roomId: RoomId; requester: Address; streamrClient: StreamrClient }
-    >('room: sync'),
+    sync: createAction<IFingerprinted & { roomId: RoomId; requester: Address }>('room: sync'),
 
-    getStorageNodes: createAction<
-        IFingerprinted & { roomId: RoomId; streamrClient: StreamrClient }
-    >('room: get storage nodes'),
+    getStorageNodes: createAction<IFingerprinted & { roomId: RoomId }>('room: get storage nodes'),
 
     setGettingStorageNodes: createAction<{ roomId: RoomId; state: boolean }>(
         'room: set getting strorage nodes'
@@ -104,7 +96,6 @@ export const RoomAction = {
                 roomId: RoomId
                 address: string
                 state: boolean
-                streamrClient: StreamrClient
             }
     >('room: toggle storage node'),
 
@@ -124,17 +115,13 @@ export const RoomAction = {
         'room: set getting privacy'
     ),
 
-    getPrivacy: createAction<IFingerprinted & { roomId: RoomId; streamrClient: StreamrClient }>(
-        'room: get privacy'
+    getPrivacy: createAction<IFingerprinted & { roomId: RoomId }>('room: get privacy'),
+
+    registerInvite: createAction<IFingerprinted & { roomId: RoomId; invitee: Address }>(
+        'room: register invite'
     ),
 
-    registerInvite: createAction<
-        IFingerprinted & { roomId: RoomId; invitee: Address; streamrClient: StreamrClient }
-    >('room: register invite'),
-
-    fetch: createAction<{ roomId: RoomId; requester: Address; streamrClient: StreamrClient }>(
-        'room: fetch'
-    ),
+    fetch: createAction<{ roomId: RoomId; requester: Address }>('room: fetch'),
 
     setPersistingName: createAction<{ roomId: RoomId; state: boolean }>(
         'room: set persisting name'
@@ -149,13 +136,10 @@ export const RoomAction = {
     pinSticky: createAction<
         IFingerprinted & {
             requester: Address
-            streamrClient: StreamrClient
         }
     >('room: pin sticky'),
 
-    unpin: createAction<
-        IFingerprinted & { roomId: RoomId; requester: Address; streamrClient: StreamrClient }
-    >('room: unpin'),
+    unpin: createAction<IFingerprinted & { roomId: RoomId; requester: Address }>('room: unpin'),
 
     setPinning: createAction<{ owner: Address; roomId: RoomId; state: boolean }>(
         'room: set pinning'
@@ -166,9 +150,7 @@ export const RoomAction = {
         tokenGate: CachedTokenGate | null
     }>('room: cache token gate'),
 
-    search: createAction<IFingerprinted & { roomId: RoomId; streamrClient: StreamrClient }>(
-        'room: search'
-    ),
+    search: createAction<IFingerprinted & { roomId: RoomId }>('room: search'),
 
     cacheSearchResult: createAction<{
         roomId: RoomId

--- a/src/features/room/index.ts
+++ b/src/features/room/index.ts
@@ -44,7 +44,6 @@ export const RoomAction = {
             params: IRoom
             privacy: PrivacySetting
             storage: boolean
-            streamrClient: StreamrClient
         }
     >('room: create'),
 

--- a/src/features/room/sagas/create.saga.ts
+++ b/src/features/room/sagas/create.saga.ts
@@ -1,6 +1,6 @@
 import db from '$/utils/db'
 import { put, takeEvery } from 'redux-saga/effects'
-import {
+import StreamrClient, {
     Stream,
     StreamMetadata,
     StreamPermission,
@@ -22,6 +22,7 @@ import retoast from '$/features/toaster/helpers/retoast'
 import createTokenGatePolicy from '$/features/tokenGatedRooms/helpers/createTokenGatePolicy'
 import recover from '$/utils/recover'
 import i18n from '$/utils/i18n'
+import getTransactionalClient from '$/utils/getTransactionalClient'
 
 function* onCreateAction({
     payload: {
@@ -29,7 +30,6 @@ function* onCreateAction({
         storage,
         params: { owner, ...params },
         requester,
-        streamrClient,
     },
 }: ReturnType<typeof RoomAction.create>) {
     let tc: Controller | undefined
@@ -90,6 +90,8 @@ function* onCreateAction({
         dismissToast = true
 
         yield preflight(requester)
+
+        const streamrClient: StreamrClient = yield getTransactionalClient()
 
         const stream = yield* recover(function* () {
             const s: Stream = yield streamrClient.createStream({

--- a/src/features/room/sagas/create.saga.ts
+++ b/src/features/room/sagas/create.saga.ts
@@ -37,11 +37,10 @@ function* onCreateAction({
     let dismissToast = false
 
     try {
-        yield preflight(requester)
-
-        // `payload.id` is a partial room id. The real room id gets constructed by the
-        // client from the given value and the account address that creates the stream.
-
+        /**
+         * `payload.id` is a partial room id. The real room id gets constructed by the
+         * client from the given value and the account address that creates the stream.
+         */
         const { id, name: description, ...metadata }: Omit<IRoom, 'owner'> = params
 
         const {
@@ -89,6 +88,8 @@ function* onCreateAction({
         })
 
         dismissToast = true
+
+        yield preflight(requester)
 
         const stream = yield* recover(function* () {
             const s: Stream = yield streamrClient.createStream({

--- a/src/features/room/sagas/create.saga.ts
+++ b/src/features/room/sagas/create.saga.ts
@@ -112,7 +112,6 @@ function* onCreateAction({
                 roomId: stream.id,
                 tokenIds,
                 minRequiredBalance,
-                streamrClient,
                 tokenType,
                 stakingEnabled,
             })
@@ -164,7 +163,6 @@ function* onCreateAction({
                     address: STREAMR_STORAGE_NODE_GERMANY,
                     state: true,
                     requester,
-                    streamrClient,
                     fingerprint: Flag.isTogglingStorageNode(
                         stream.id,
                         STREAMR_STORAGE_NODE_GERMANY

--- a/src/features/room/sagas/del.saga.ts
+++ b/src/features/room/sagas/del.saga.ts
@@ -6,12 +6,14 @@ import takeEveryUnique from '$/utils/takeEveryUnique'
 import toast from '$/features/toaster/helpers/toast'
 import { ToastType } from '$/components/Toast'
 import i18n from '$/utils/i18n'
+import StreamrClient from 'streamr-client'
+import getTransactionalClient from '$/utils/getTransactionalClient'
 
-function* onDeleteAction({
-    payload: { roomId, requester, streamrClient },
-}: ReturnType<typeof RoomAction.delete>) {
+function* onDeleteAction({ payload: { roomId, requester } }: ReturnType<typeof RoomAction.delete>) {
     try {
         yield preflight(requester)
+
+        const streamrClient: StreamrClient = yield getTransactionalClient()
 
         yield streamrClient.deleteStream(roomId)
 

--- a/src/features/room/sagas/fetch.saga.ts
+++ b/src/features/room/sagas/fetch.saga.ts
@@ -8,11 +8,9 @@ import { Stream } from 'streamr-client'
 import getRoomMetadata from '$/utils/getRoomMetadata'
 import fetchStream from '$/utils/fetchStream'
 
-function* onFetchAction({
-    payload: { roomId, requester, streamrClient },
-}: ReturnType<typeof RoomAction.fetch>) {
+function* onFetchAction({ payload: { roomId, requester } }: ReturnType<typeof RoomAction.fetch>) {
     try {
-        const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+        const stream: Stream | null = yield fetchStream(roomId)
 
         if (!stream) {
             throw new RoomNotFoundError(roomId)

--- a/src/features/room/sagas/getPrivacy.saga.ts
+++ b/src/features/room/sagas/getPrivacy.saga.ts
@@ -9,9 +9,7 @@ import fetchStream from '$/utils/fetchStream'
 import { selectPrivacy } from '$/hooks/usePrivacy'
 import fetchPrivacy from '$/utils/fetchPrivacy'
 
-function* onGetPrivacyAction({
-    payload: { roomId, streamrClient },
-}: ReturnType<typeof RoomAction.getPrivacy>) {
+function* onGetPrivacyAction({ payload: { roomId } }: ReturnType<typeof RoomAction.getPrivacy>) {
     try {
         const currentPrivacy: PrivacySetting | undefined = yield select(selectPrivacy(roomId))
 
@@ -19,7 +17,7 @@ function* onGetPrivacyAction({
             return
         }
 
-        const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+        const stream: Stream | null = yield fetchStream(roomId)
 
         if (!stream) {
             throw new RoomNotFoundError(roomId)

--- a/src/features/room/sagas/getStorageNodes.saga.ts
+++ b/src/features/room/sagas/getStorageNodes.saga.ts
@@ -7,10 +7,10 @@ import takeEveryUnique from '$/utils/takeEveryUnique'
 import fetchStream from '$/utils/fetchStream'
 
 function* onGetStorageNodesAction({
-    payload: { roomId, streamrClient },
+    payload: { roomId },
 }: ReturnType<typeof RoomAction.getStorageNodes>) {
     try {
-        const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+        const stream: Stream | null = yield fetchStream(roomId)
 
         if (!stream) {
             throw new RoomNotFoundError(roomId)

--- a/src/features/room/sagas/registerInvite.saga.ts
+++ b/src/features/room/sagas/registerInvite.saga.ts
@@ -1,5 +1,5 @@
 import { put } from 'redux-saga/effects'
-import { StreamPermission } from 'streamr-client'
+import StreamrClient, { StreamPermission } from 'streamr-client'
 import { RoomAction } from '..'
 import handleError from '$/utils/handleError'
 import takeEveryUnique from '$/utils/takeEveryUnique'
@@ -7,11 +7,14 @@ import waitForPermissions from '$/utils/waitForPermissions'
 import isSameAddress from '$/utils/isSameAddress'
 import toast from '$/features/toaster/helpers/toast'
 import i18n from '$/utils/i18n'
+import getTransactionalClient from '$/utils/getTransactionalClient'
 
 function* onRegisterInviteAction({
-    payload: { roomId, invitee, streamrClient },
+    payload: { roomId, invitee },
 }: ReturnType<typeof RoomAction.registerInvite>) {
     try {
+        const streamrClient: StreamrClient = yield getTransactionalClient()
+
         // Invite detector tends to trigger the invitation event prematurely. In other
         // words, at times we've gotta wait a couple of seconds for `GRANT` permission
         // to be fully established and propagated.
@@ -40,7 +43,6 @@ function* onRegisterInviteAction({
             RoomAction.fetch({
                 roomId,
                 requester: invitee,
-                streamrClient,
             })
         )
     } catch (e) {

--- a/src/features/room/sagas/rename.saga.ts
+++ b/src/features/room/sagas/rename.saga.ts
@@ -17,10 +17,10 @@ import fetchStream from '$/utils/fetchStream'
 import i18n from '$/utils/i18n'
 
 function* onRenameAction({
-    payload: { roomId, name, requester, streamrClient },
+    payload: { roomId, name, requester },
 }: ReturnType<typeof RoomAction.rename>) {
     try {
-        const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+        const stream: Stream | null = yield fetchStream(roomId)
 
         if (!stream) {
             throw new RoomNotFoundError(roomId)
@@ -47,7 +47,6 @@ function* onRenameAction({
                         RoomAction.sync({
                             roomId,
                             requester,
-                            streamrClient,
                             fingerprint: Flag.isSyncingRoom(roomId),
                         })
                     )

--- a/src/features/room/sagas/sync.saga.ts
+++ b/src/features/room/sagas/sync.saga.ts
@@ -9,11 +9,9 @@ import takeEveryUnique from '$/utils/takeEveryUnique'
 import getRoomMetadata from '$/utils/getRoomMetadata'
 import fetchStream from '$/utils/fetchStream'
 
-function* onSyncAction({
-    payload: { roomId, requester, streamrClient },
-}: ReturnType<typeof RoomAction.sync>) {
+function* onSyncAction({ payload: { roomId, requester } }: ReturnType<typeof RoomAction.sync>) {
     try {
-        const stream: Stream | null = yield fetchStream(roomId, streamrClient)
+        const stream: Stream | null = yield fetchStream(roomId)
 
         if (stream) {
             const [permissions, isPublic]: UserPermissions = yield getUserPermissions(

--- a/src/features/room/sagas/toggleStorageNode.saga.ts
+++ b/src/features/room/sagas/toggleStorageNode.saga.ts
@@ -6,12 +6,16 @@ import takeEveryUnique from '$/utils/takeEveryUnique'
 import toast from '$/features/toaster/helpers/toast'
 import { ToastType } from '$/components/Toast'
 import i18n from '$/utils/i18n'
+import StreamrClient from 'streamr-client'
+import getTransactionalClient from '$/utils/getTransactionalClient'
 
 function* onToggleStorageNodeAction({
-    payload: { roomId, address, state, requester, streamrClient },
+    payload: { roomId, address, state, requester },
 }: ReturnType<typeof RoomAction.toggleStorageNode>) {
     try {
         yield preflight(requester)
+
+        const streamrClient: StreamrClient = yield getTransactionalClient()
 
         yield put(
             RoomAction.setTogglingStorageNode({

--- a/src/features/room/sagas/unpin.saga.ts
+++ b/src/features/room/sagas/unpin.saga.ts
@@ -8,9 +8,7 @@ import i18n from '$/utils/i18n'
 import takeEveryUnique from '$/utils/takeEveryUnique'
 import { put } from 'redux-saga/effects'
 
-function* onUnpinAction({
-    payload: { roomId, requester, streamrClient },
-}: ReturnType<typeof RoomAction.unpin>) {
+function* onUnpinAction({ payload: { roomId, requester } }: ReturnType<typeof RoomAction.unpin>) {
     try {
         yield db.rooms
             .where({ owner: requester.toLowerCase(), id: roomId })
@@ -20,7 +18,6 @@ function* onUnpinAction({
             RoomAction.sync({
                 roomId,
                 requester,
-                streamrClient,
                 fingerprint: Flag.isSyncingRoom(roomId),
             })
         )

--- a/src/features/rooms/index.ts
+++ b/src/features/rooms/index.ts
@@ -2,11 +2,10 @@ import { createAction, createReducer } from '@reduxjs/toolkit'
 import { all } from 'redux-saga/effects'
 import { SEE_SAGA } from '$/utils/consts'
 import fetch from './sagas/fetch.saga'
-import StreamrClient from 'streamr-client'
 import { Address } from '$/types'
 
 export const RoomsAction = {
-    fetch: createAction<{ requester: Address; streamrClient: StreamrClient }>('rooms: fetch'),
+    fetch: createAction<{ requester: Address }>('rooms: fetch'),
 }
 
 const reducer = createReducer({}, (builder) => {

--- a/src/features/rooms/sagas/fetch.saga.ts
+++ b/src/features/rooms/sagas/fetch.saga.ts
@@ -5,6 +5,7 @@ import { Prefix } from '$/types'
 import handleError from '$/utils/handleError'
 import { RoomAction } from '../../room'
 import { RoomId } from '../../room/types'
+import getTransactionalClient from '$/utils/getTransactionalClient'
 
 async function getRoomIds(client: StreamrClient, account: string) {
     const ids: RoomId[] = []
@@ -21,10 +22,10 @@ async function getRoomIds(client: StreamrClient, account: string) {
     return ids
 }
 
-function* onFetchAction({
-    payload: { requester, streamrClient },
-}: ReturnType<typeof RoomsAction.fetch>) {
+function* onFetchAction({ payload: { requester } }: ReturnType<typeof RoomsAction.fetch>) {
     try {
+        const streamrClient: StreamrClient = yield getTransactionalClient()
+
         const ids: RoomId[] = yield getRoomIds(streamrClient, requester)
 
         for (let i = 0; i < ids.length; i++) {
@@ -32,7 +33,6 @@ function* onFetchAction({
                 RoomAction.fetch({
                     roomId: ids[i],
                     requester,
-                    streamrClient,
                 })
             )
         }

--- a/src/features/tokenGatedRooms/helpers/createTokenGatePolicy.ts
+++ b/src/features/tokenGatedRooms/helpers/createTokenGatePolicy.ts
@@ -8,7 +8,7 @@ import handleError from '$/utils/handleError'
 import preflight from '$/utils/preflight'
 import { Contract, providers, BigNumber } from 'ethers'
 import { call, race, retry, spawn, take } from 'redux-saga/effects'
-import StreamrClient, { StreamPermission } from 'streamr-client'
+import { StreamPermission } from 'streamr-client'
 import { abi as erc20abi } from '$/contracts/Factories/ERC20PolicyFactory.sol/ERC20PolicyFactory.json'
 import { abi as erc721abi } from '$/contracts/Factories/ERC721PolicyFactory.sol/ERC721PolicyFactory.json'
 import { abi as erc777abi } from '$/contracts/Factories/ERC777PolicyFactory.sol/ERC777PolicyFactory.json'
@@ -63,7 +63,6 @@ interface Params {
     minRequiredBalance?: string
     tokenIds: string[]
     stakingEnabled: boolean
-    streamrClient: StreamrClient
 }
 
 export default function createTokenGatePolicy({
@@ -74,7 +73,6 @@ export default function createTokenGatePolicy({
     minRequiredBalance,
     tokenIds,
     stakingEnabled,
-    streamrClient,
 }: Params) {
     return spawn(function* () {
         yield race([
@@ -92,8 +90,6 @@ export default function createTokenGatePolicy({
 
                     dismissToast = true
 
-                    yield preflight(requester)
-
                     const factory = Factory[tokenType.standard]
 
                     if (!factory) {
@@ -101,6 +97,8 @@ export default function createTokenGatePolicy({
                     }
 
                     const { abi, address } = factory
+
+                    yield preflight(requester)
 
                     const provider = yield* getWalletProvider()
 
@@ -190,9 +188,7 @@ export default function createTokenGatePolicy({
                                     },
                                 ],
                                 {
-                                    provider,
                                     requester,
-                                    streamrClient,
                                 }
                             )
                         },

--- a/src/features/wallet/helpers/changeAccount.ts
+++ b/src/features/wallet/helpers/changeAccount.ts
@@ -4,6 +4,7 @@ import { EnsAction } from '$/features/ens'
 import { Flag } from '$/features/flag/types'
 import { IPreference } from '$/features/preferences/types'
 import { RoomAction } from '$/features/room'
+import { RoomsAction } from '$/features/rooms'
 import { WalletAction } from '$/features/wallet'
 import db from '$/utils/db'
 import { call, put } from 'redux-saga/effects'
@@ -25,12 +26,17 @@ export default function changeAccount(
             return
         }
 
-        const { account, streamrClient } = payload
+        const { account } = payload
+
+        yield put(
+            RoomsAction.fetch({
+                requester: account,
+            })
+        )
 
         yield put(
             RoomAction.pinSticky({
                 requester: account,
-                streamrClient,
                 fingerprint: Flag.isPinningStickyRooms(account),
             })
         )

--- a/src/features/wallet/types.ts
+++ b/src/features/wallet/types.ts
@@ -14,6 +14,7 @@ export interface WalletState {
     account: string | undefined | null
     integrationId: WalletIntegrationId | undefined
     client: undefined | StreamrClient
+    transactionalClient: undefined | StreamrClient
 }
 
 export type ConnectorMap = Partial<

--- a/src/hooks/useAbility.ts
+++ b/src/hooks/useAbility.ts
@@ -1,7 +1,6 @@
 import { Flag } from '$/features/flag/types'
 import { PermissionsAction } from '$/features/permissions'
 import { RoomId } from '$/features/room/types'
-import { useWalletClient } from '$/features/wallet/hooks'
 import { OptionalAddress, State } from '$/types'
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
@@ -42,10 +41,8 @@ export default function useAbility(
 
     const cache = useSelector(selectPermissionCache(roomId, address, permission))
 
-    const streamrClient = useWalletClient()
-
     useEffect(() => {
-        if (!roomId || !address || !streamrClient) {
+        if (!roomId || !address) {
             return
         }
 
@@ -54,11 +51,10 @@ export default function useAbility(
                 roomId,
                 address,
                 permission,
-                streamrClient,
                 fingerprint: Flag.isPermissionBeingFetched(roomId, address, permission),
             })
         )
-    }, [roomId, address, permission, cache, streamrClient])
+    }, [roomId, address, permission, cache])
 
     return useSelector(selectAbility(roomId, address, permission))
 }

--- a/src/hooks/useAcceptInvite.ts
+++ b/src/hooks/useAcceptInvite.ts
@@ -1,7 +1,7 @@
 import { Flag } from '$/features/flag/types'
 import { PermissionsAction } from '$/features/permissions'
 import { useSelectedRoomId } from '$/features/room/hooks'
-import { useWalletAccount, useWalletClient } from '$/features/wallet/hooks'
+import { useWalletAccount } from '$/features/wallet/hooks'
 import { useCallback } from 'react'
 import { useDispatch } from 'react-redux'
 
@@ -14,10 +14,8 @@ export default function useAcceptInvite() {
 
     const requester = useWalletAccount()
 
-    const streamrClient = useWalletClient()
-
     return useCallback(() => {
-        if (!member || !roomId || !requester || !streamrClient) {
+        if (!member || !roomId || !requester) {
             return
         }
 
@@ -26,9 +24,8 @@ export default function useAcceptInvite() {
                 member,
                 roomId,
                 requester,
-                streamrClient,
                 fingerprint: Flag.isInviteBeingAccepted(roomId, member),
             })
         )
-    }, [member, roomId, requester, streamrClient])
+    }, [member, roomId, requester])
 }

--- a/src/hooks/useAddMemberModal.ts
+++ b/src/hooks/useAddMemberModal.ts
@@ -2,7 +2,7 @@ import AddMemberModal from '$/components/modals/AddMemberModal'
 import { Flag } from '$/features/flag/types'
 import { PermissionsAction } from '$/features/permissions'
 import { useSelectedRoomId } from '$/features/room/hooks'
-import { useWalletAccount, useWalletClient } from '$/features/wallet/hooks'
+import { useWalletAccount } from '$/features/wallet/hooks'
 import useModalDialog from '$/hooks/useModalDialog'
 import { OptionalAddress } from '$/types'
 import { useCallback } from 'react'
@@ -15,12 +15,10 @@ export default function useAddMemberModal() {
 
     const roomId = useSelectedRoomId()
 
-    const streamrClient = useWalletClient()
-
     const requester = useWalletAccount()
 
     const open = useCallback(async () => {
-        if (!roomId || !streamrClient || !requester) {
+        if (!roomId || !requester) {
             return
         }
 
@@ -41,11 +39,10 @@ export default function useAddMemberModal() {
                 roomId,
                 member,
                 requester,
-                streamrClient,
                 fingerprint: Flag.isMemberBeingAdded(roomId, member),
             })
         )
-    }, [openModal, roomId, streamrClient, requester])
+    }, [openModal, roomId, requester])
 
     return {
         open,

--- a/src/hooks/useAddRoomModal.tsx
+++ b/src/hooks/useAddRoomModal.tsx
@@ -2,7 +2,7 @@ import AddRoomModal, { NewRoom } from '$/components/modals/AddRoomModal'
 import AddTokenGatedRoomModal from '$/components/modals/AddTokenGatedRoomModal'
 import { RoomAction } from '$/features/room'
 import { TokenTypes } from '$/features/tokenGatedRooms/types'
-import { useWalletAccount, useWalletClient } from '$/features/wallet/hooks'
+import { useWalletAccount } from '$/features/wallet/hooks'
 import useModalDialog from '$/hooks/useModalDialog'
 import { Prefix, PrivacySetting } from '$/types'
 import { useCallback } from 'react'
@@ -16,12 +16,10 @@ export default function useAddRoomModal() {
 
     const account = useWalletAccount()
 
-    const streamrClient = useWalletClient()
-
     const dispatch = useDispatch()
 
     const open = useCallback(async () => {
-        if (!account || !streamrClient) {
+        if (!account) {
             return
         }
 
@@ -55,7 +53,6 @@ export default function useAddRoomModal() {
                             privacy: params.privacy,
                             storage: params.storage,
                             requester: account,
-                            streamrClient,
                         })
                     )
 
@@ -86,7 +83,6 @@ export default function useAddRoomModal() {
                             privacy: params.privacy,
                             storage: params.storage,
                             requester: account,
-                            streamrClient,
                         })
                     )
 
@@ -98,7 +94,7 @@ export default function useAddRoomModal() {
                 break
             }
         }
-    }, [openNameModal, account, streamrClient])
+    }, [openNameModal, account])
 
     return {
         open,

--- a/src/hooks/useDetectMembersEffect.ts
+++ b/src/hooks/useDetectMembersEffect.ts
@@ -1,7 +1,6 @@
 import { Flag } from '$/features/flag/types'
 import { PermissionsAction } from '$/features/permissions'
 import { useSelectedRoomId } from '$/features/room/hooks'
-import { useWalletClient } from '$/features/wallet/hooks'
 import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 
@@ -10,21 +9,18 @@ import { useDispatch } from 'react-redux'
 export default function useDetectMembersEffect() {
     const selectedRoomId = useSelectedRoomId()
 
-    const streamrClient = useWalletClient()
-
     const dispatch = useDispatch()
 
     useEffect(() => {
-        if (!selectedRoomId || !streamrClient) {
+        if (!selectedRoomId) {
             return
         }
 
         dispatch(
             PermissionsAction.detectRoomMembers({
                 roomId: selectedRoomId,
-                streamrClient,
                 fingerprint: Flag.isDetectingMembers(selectedRoomId),
             })
         )
-    }, [dispatch, selectedRoomId, streamrClient])
+    }, [dispatch, selectedRoomId])
 }

--- a/src/hooks/useJoin.ts
+++ b/src/hooks/useJoin.ts
@@ -3,7 +3,7 @@ import { Flag } from '$/features/flag/types'
 import { PermissionsAction } from '$/features/permissions'
 import { useSelectedRoomId } from '$/features/room/hooks'
 import usePrivacy from '$/hooks/usePrivacy'
-import { useWalletAccount, useWalletClient } from '$/features/wallet/hooks'
+import { useWalletAccount } from '$/features/wallet/hooks'
 import { PrivacySetting } from '$/types'
 import { useCallback } from 'react'
 import { useDispatch } from 'react-redux'
@@ -17,12 +17,10 @@ export default function useJoin() {
 
     const requester = useWalletAccount()
 
-    const streamrClient = useWalletClient()
-
     const privacy = usePrivacy(roomId)
 
     const cb = useCallback(() => {
-        if (!roomId || !delegatedAddress || !requester || !streamrClient) {
+        if (!roomId || !delegatedAddress || !requester) {
             return
         }
 
@@ -31,11 +29,10 @@ export default function useJoin() {
                 roomId,
                 delegatedAddress,
                 requester,
-                streamrClient,
                 fingerprint: Flag.isDelegatedAccountBeingPromoted(roomId, delegatedAddress),
             })
         )
-    }, [roomId, delegatedAddress, requester, streamrClient])
+    }, [roomId, delegatedAddress, requester])
 
     if (privacy === PrivacySetting.TokenGated) {
         return cb

--- a/src/hooks/usePreselectRoomEffect.ts
+++ b/src/hooks/usePreselectRoomEffect.ts
@@ -1,6 +1,6 @@
 import { Flag } from '$/features/flag/types'
 import { RoomAction } from '$/features/room'
-import { useWalletAccount, useWalletClient } from '$/features/wallet/hooks'
+import { useWalletAccount } from '$/features/wallet/hooks'
 import { Prefix } from '$/types'
 import pathnameToRoomIdPartials from '$/utils/pathnameToRoomIdPartials'
 import { useEffect, useRef } from 'react'
@@ -12,8 +12,6 @@ export default function usePreselectRoomEffect() {
 
     const dispatch = useDispatch()
 
-    const streamrClient = useWalletClient()
-
     const { pathname } = useLocation()
 
     const pathnameRef = useRef(pathname)
@@ -23,7 +21,7 @@ export default function usePreselectRoomEffect() {
     }, [pathname])
 
     useEffect(() => {
-        if (!streamrClient || !account) {
+        if (!account) {
             return
         }
 
@@ -38,9 +36,8 @@ export default function usePreselectRoomEffect() {
             RoomAction.preselect({
                 account,
                 roomId,
-                streamrClient,
                 fingerprint: Flag.isPreselectingRoom(roomId),
             })
         )
-    }, [account, dispatch, streamrClient])
+    }, [account, dispatch])
 }

--- a/src/hooks/usePromoteDelegatedAccount.ts
+++ b/src/hooks/usePromoteDelegatedAccount.ts
@@ -3,7 +3,7 @@ import { Flag } from '$/features/flag/types'
 import { PermissionsAction } from '$/features/permissions'
 import { useSelectedRoomId } from '$/features/room/hooks'
 import usePrivacy from '$/hooks/usePrivacy'
-import { useWalletAccount, useWalletClient } from '$/features/wallet/hooks'
+import { useWalletAccount } from '$/features/wallet/hooks'
 import { PrivacySetting } from '$/types'
 import { useCallback } from 'react'
 import { useDispatch } from 'react-redux'
@@ -17,12 +17,10 @@ export default function usePromoteDelegatedAccount() {
 
     const requester = useWalletAccount()
 
-    const streamrClient = useWalletClient()
-
     const privacy = usePrivacy(roomId)
 
     const cb = useCallback(() => {
-        if (!roomId || !delegatedAddress || !requester || !streamrClient) {
+        if (!roomId || !delegatedAddress || !requester) {
             return
         }
 
@@ -31,11 +29,10 @@ export default function usePromoteDelegatedAccount() {
                 roomId,
                 delegatedAddress,
                 requester,
-                streamrClient,
                 fingerprint: Flag.isDelegatedAccountBeingPromoted(roomId, delegatedAddress),
             })
         )
-    }, [roomId, delegatedAddress, requester, streamrClient])
+    }, [roomId, delegatedAddress, requester])
 
     if (privacy === PrivacySetting.Private || privacy === PrivacySetting.Public) {
         return cb

--- a/src/utils/createStore.ts
+++ b/src/utils/createStore.ts
@@ -58,6 +58,7 @@ export default function createStore(reducer = defaultReducer) {
                         ignoredPaths: [
                             'wallet.provider',
                             'wallet.client',
+                            'wallet.transactionalClient',
                             'delegation.client',
                             'misc.navigate',
                             'anon.rooms',

--- a/src/utils/fetchStream.ts
+++ b/src/utils/fetchStream.ts
@@ -6,14 +6,17 @@ import { selectPrivacy } from '$/hooks/usePrivacy'
 import { PrivacySetting } from '$/types'
 import fetchPrivacy from '$/utils/fetchPrivacy'
 import getRoomMetadata from '$/utils/getRoomMetadata'
+import getTransactionalClient from '$/utils/getTransactionalClient'
 import handleError from '$/utils/handleError'
 import { call, fork, put, select } from 'redux-saga/effects'
 import type StreamrClient from 'streamr-client'
 import type { Stream } from 'streamr-client'
 
-export default function fetchStream(roomId: RoomId, streamrClient: StreamrClient) {
+export default function fetchStream(roomId: RoomId) {
     return call(function* () {
         try {
+            const streamrClient: StreamrClient = yield getTransactionalClient()
+
             const stream: Stream = yield streamrClient.getStream(roomId)
 
             const {

--- a/src/utils/getTransactionalClient.ts
+++ b/src/utils/getTransactionalClient.ts
@@ -1,0 +1,17 @@
+import { State } from '$/types'
+import { call, select } from 'redux-saga/effects'
+import StreamrClient from 'streamr-client'
+
+export default function getTransactionalClient() {
+    return call(function* () {
+        const client: StreamrClient | undefined = yield select(
+            ({ wallet }: State) => wallet.transactionalClient
+        )
+
+        if (!client) {
+            throw new Error('Transactional client is missing')
+        }
+
+        return client
+    })
+}

--- a/src/utils/networkPreflight.ts
+++ b/src/utils/networkPreflight.ts
@@ -2,7 +2,9 @@ import addNetwork from '$/utils/addNetwork'
 import switchNetwork from '$/utils/switchNetwork'
 import isCorrectNetwork from './isCorrectNetwork'
 import getWalletProvider from '$/utils/getWalletProvider'
-import { call } from 'redux-saga/effects'
+import { call, put } from 'redux-saga/effects'
+import { WalletAction } from '$/features/wallet'
+import getNewStreamrClient from '$/utils/getNewStreamrClient'
 
 export default function networkPreflight() {
     return call(function* () {
@@ -21,5 +23,13 @@ export default function networkPreflight() {
 
             yield addNetwork(provider)
         }
+
+        yield put(
+            WalletAction.setTransactionalClient({
+                streamrClient: getNewStreamrClient({
+                    ethereum: provider,
+                }),
+            })
+        )
     })
 }


### PR DESCRIPTION
Scary PR but the idea is simple:
- We have a new client field in the store (see `wallet.transactionalClient`).
- The new client is equal to `wallet.client` initially but is kept up-to-date by `networkPreflight`. On every network change we have a new transactional client (see `networkPreflight` for details).
- The new client is used for everything except for messaging: sending, receiving and resending (see `useSubscriber` for details).
- The new client isn't passed around via props. Instead we have a getter utility (see `getTransactionalClient`).

@bearni95 FYI!